### PR TITLE
Factor out a Grid class

### DIFF
--- a/GrowingFlowers/GrowingFlowers.js
+++ b/GrowingFlowers/GrowingFlowers.js
@@ -13,11 +13,11 @@ const OFFSET_X = (WIDTH - GRID_WIDTH_PX) / 2;
 const OFFSET_Y = (HEIGHT - GRID_HEIGHT_PX) / 2;
 
 const FLOWERPOT = {
-    x: 25 - 4,
-    y: GRID_HEIGHT - 6,
-    width: 8,
-    height: 6,
-}
+  x: 25 - 4,
+  y: GRID_HEIGHT - 6,
+  width: 8,
+  height: 6,
+};
 
 // No growth below this y value
 const START_X = 25;
@@ -28,72 +28,72 @@ const START_Y = FLOWERPOT.y - 2;
 const GROWTH = new Growth(GRID_WIDTH, START_Y + 1, START_X, START_Y);
 
 export const sketch = (p) => {
-    const FLOWER_COLORS = [
-        // Purple
-        p.color(148, 3, 252),
-        // Red
-        p.color(255, 0, 0),
-        // Pale blue
-        p.color(173, 224, 237),
-        // Yellow
-        p.color(255, 208, 38),
-        // Blue
-        p.color(34, 5, 255),
-        // Orange
-        p.color(255, 149, 0),
-    ]
+  const FLOWER_COLORS = [
+    // Purple
+    p.color(148, 3, 252),
+    // Red
+    p.color(255, 0, 0),
+    // Pale blue
+    p.color(173, 224, 237),
+    // Yellow
+    p.color(255, 208, 38),
+    // Blue
+    p.color(34, 5, 255),
+    // Orange
+    p.color(255, 149, 0),
+  ];
 
-    let flower_color;
-    p.setup = () => {
-        p.createCanvas(WIDTH, HEIGHT);
-        flower_color = p.random(FLOWER_COLORS);
-    }
+  let flower_color;
+  p.setup = () => {
+    p.createCanvas(WIDTH, HEIGHT);
+    flower_color = p.random(FLOWER_COLORS);
+  };
 
-    p.draw = () => {
-        p.background(0);
-    
-        p.push();
-        p.translate(OFFSET_X, OFFSET_Y);
-    
-        // Draw a trellis
-        p.stroke(71, 52, 26);
-        p.strokeWeight(8);
-    
-        // Draw the bottom-most stem in green
-        const STEM_COLOR = p.color(33, 112, 37);
-        p.stroke(STEM_COLOR)
-        p.strokeWeight(4);
-        p.noFill();
-        p.line(
-            START_X * SPACING,
-            START_Y * SPACING,
-            START_X * SPACING,
-            (START_Y + 2) * SPACING
-        );
-        
-        GROWTH.draw(p, SPACING, STEM_COLOR, flower_color);
-    
-        // Draw the flowerpot in brown. Draw it last so it hides the bottom of
-        // the bottom stem
-        p.fill(71, 52, 26);
-        p.stroke(0);
-        p.rect(
-            (FLOWERPOT.x + 1) * SPACING,
-            FLOWERPOT.y * SPACING,
-            (FLOWERPOT.width - 2) * SPACING,
-            FLOWERPOT.height * SPACING
-        );
-        p.rect(
-            FLOWERPOT.x * SPACING,
-            FLOWERPOT.y * SPACING,
-            FLOWERPOT.width * SPACING, 
-            SPACING
-        );
-    
-        p.pop();
-    
-        if (p.frameCount % 10 == 0) {
-            GROWTH.grow_step();
-        }
+  p.draw = () => {
+    p.background(0);
+
+    p.push();
+    p.translate(OFFSET_X, OFFSET_Y);
+
+    // Draw a trellis
+    p.stroke(71, 52, 26);
+    p.strokeWeight(8);
+
+    // Draw the bottom-most stem in green
+    const STEM_COLOR = p.color(33, 112, 37);
+    p.stroke(STEM_COLOR);
+    p.strokeWeight(4);
+    p.noFill();
+    p.line(
+      START_X * SPACING,
+      START_Y * SPACING,
+      START_X * SPACING,
+      (START_Y + 2) * SPACING
+    );
+
+    GROWTH.draw(p, SPACING, STEM_COLOR, flower_color);
+
+    // Draw the flowerpot in brown. Draw it last so it hides the bottom of
+    // the bottom stem
+    p.fill(71, 52, 26);
+    p.stroke(0);
+    p.rect(
+      (FLOWERPOT.x + 1) * SPACING,
+      FLOWERPOT.y * SPACING,
+      (FLOWERPOT.width - 2) * SPACING,
+      FLOWERPOT.height * SPACING
+    );
+    p.rect(
+      FLOWERPOT.x * SPACING,
+      FLOWERPOT.y * SPACING,
+      FLOWERPOT.width * SPACING,
+      SPACING
+    );
+
+    p.pop();
+
+    if (p.frameCount % 10 == 0) {
+      GROWTH.grow_step();
     }
-}
+  };
+};

--- a/GrowingFlowers/Growth.js
+++ b/GrowingFlowers/Growth.js
@@ -24,7 +24,7 @@ export class Growth {
     this.grid = new Grid(grid_height, grid_width);
 
     const start_index = new Index2D(start_y, start_x);
-    this.grid.set_2d(start_index, new Node(start_index, undefined, 0));
+    this.grid.set(start_index, new Node(start_index, undefined, 0));
 
     // Start simple with a stack
     this.frontier = [start_index];
@@ -85,7 +85,7 @@ export class Growth {
 
     // Neighbors are only valid if that grid cell is empty
     const valid_neighbors = possible_neighbors.filter(
-      (index) => this.grid.get_2d(index) === undefined
+      (index) => this.grid.get(index) === undefined
     );
 
     // For the first few steps, make the chance of skipping low
@@ -98,7 +98,7 @@ export class Growth {
         continue;
       }
 
-      this.grid.set_2d(
+      this.grid.set(
         neighbor_index,
         new Node(neighbor_index, current_index, this.growth_step)
       );
@@ -114,7 +114,7 @@ export class Growth {
 
     // If we didn't add branches, mark this node as a flower
     if (!added_branches) {
-      this.grid.get_2d(current_index).is_flower = true;
+      this.grid.get(current_index).is_flower = true;
     }
   }
 

--- a/GrowingFlowers/Growth.js
+++ b/GrowingFlowers/Growth.js
@@ -1,10 +1,12 @@
+import { Grid, Index2D } from "../sketchlib/Grid.js";
+
 const MAX_GROWTH_STEPS = 2000;
 const BUD_TIME = 10;
 const EARLY_GROWTH_TIME = 10;
 
 class Node {
-  constructor(index, parent_index, growth_step) {
-    this.index = index;
+  constructor(index_2d, parent_index, growth_step) {
+    this.index_2d = index_2d;
     this.parent_index = parent_index;
     this.growth_step = growth_step;
 
@@ -19,10 +21,10 @@ export class Growth {
     this.grid_width = grid_width;
     this.grid_height = grid_height;
 
-    this.grid = new Array(grid_width * grid_height);
+    this.grid = new Grid(grid_height, grid_width);
 
-    const start_index = this.hash(start_x, start_y);
-    this.grid[start_index] = new Node(start_index, undefined, 0);
+    const start_index = new Index2D(start_y, start_x);
+    this.grid.set_2d(start_index, new Node(start_index, undefined, 0));
 
     // Start simple with a stack
     this.frontier = [start_index];
@@ -30,16 +32,7 @@ export class Growth {
     this.growth_step = 0;
   }
 
-  hash(x, y) {
-    return y * this.grid_width + x;
-  }
-
-  unhash(index) {
-    return [index % this.grid_width, Math.floor(index / this.grid_width)];
-  }
-
   neighbor_indices(index) {
-    const [x, y] = this.unhash(index);
     const neighbors = [];
 
     // List neighbors in order from bottom to top so
@@ -119,7 +112,7 @@ export class Growth {
 
     // If we didn't add branches, mark this node as a flower
     if (!added_branches) {
-      this.grid[current_index].is_flower = true;
+      this.grid.get_2d(current_index).is_flower = true;
     }
   }
 

--- a/GrowingFlowers/Growth.js
+++ b/GrowingFlowers/Growth.js
@@ -5,8 +5,8 @@ const BUD_TIME = 10;
 const EARLY_GROWTH_TIME = 10;
 
 class Node {
-  constructor(index_2d, parent_index, growth_step) {
-    this.index_2d = index_2d;
+  constructor(index, parent_index, growth_step) {
+    this.index = index;
     this.parent_index = parent_index;
     this.growth_step = growth_step;
 
@@ -39,18 +39,21 @@ export class Growth {
     // when we push to the stack we favor upwards growth
 
     // left
-    if (x > 0) {
-      neighbors.push(index - 1);
+    const left = index.left();
+    if (left) {
+      neighbors.push(left);
     }
 
     // right
-    if (x < this.grid_width - 1) {
-      neighbors.push(index + 1);
+    const right = this.grid.right(index);
+    if (right) {
+      neighbors.push(right);
     }
 
     // up
-    if (y > 0) {
-      neighbors.push(index - this.grid_width);
+    const up = index.up();
+    if (up) {
+      neighbors.push(up);
     }
 
     return neighbors;
@@ -82,7 +85,7 @@ export class Growth {
 
     // Neighbors are only valid if that grid cell is empty
     const valid_neighbors = possible_neighbors.filter(
-      (i) => this.grid[i] === undefined
+      (index) => this.grid.get_2d(index) === undefined
     );
 
     // For the first few steps, make the chance of skipping low
@@ -95,10 +98,9 @@ export class Growth {
         continue;
       }
 
-      this.grid[neighbor_index] = new Node(
+      this.grid.set_2d(
         neighbor_index,
-        current_index,
-        this.growth_step
+        new Node(neighbor_index, current_index, this.growth_step)
       );
       this.frontier.push(neighbor_index);
       added_branches = true;
@@ -135,9 +137,9 @@ export class Growth {
       p.fill(stem_color);
       p.noFill();
       if (node.parent_index !== undefined) {
-        const [x, y] = this.unhash(node.index);
-        const [px, py] = this.unhash(node.parent_index);
-        p.line(x * spacing, y * spacing, px * spacing, py * spacing);
+        const { i, j } = node.index;
+        const { i: pi, j: pj } = node.parent_index;
+        p.line(j * spacing, i * spacing, pj * spacing, pi * spacing);
       }
 
       // Mark flower nodes for drawing that in the second pass
@@ -154,8 +156,8 @@ export class Growth {
         continue;
       }
 
-      const [x, y] = this.unhash(flower_node.index);
-      p.ellipse(x * spacing, y * spacing, 6);
+      const { i, j } = flower_node.index;
+      p.ellipse(j * spacing, i * spacing, 6);
     }
   }
 }

--- a/OrigamiTiles/OrigamiTiles.js
+++ b/OrigamiTiles/OrigamiTiles.js
@@ -1,3 +1,5 @@
+import { griderator } from "../sketchlib/Grid.js";
+
 // How many triangle tiles I made SVG files for
 const TILE_COUNT = 14;
 // Size of a single tile.
@@ -106,43 +108,39 @@ export const sketch = (p) => {
     p.push();
     p.translate(0, OFFSET_Y);
 
-    for (let i = 0; i < CANVAS_SIZE_TILES; i++) {
-      for (let j = 0; j < CANVAS_SIZE_TILES; j++) {
-        // Draw the tile bounds
-        p.stroke(255);
-        p.noFill();
-        p.rect(
-          i * TILE_SIZE + 1,
-          j * TILE_SIZE + 1,
-          TILE_SIZE - 2,
-          TILE_SIZE - 2
+    griderator(CANVAS_SIZE_TILES, CANVAS_SIZE_TILES, (i, j) => {
+      // Draw the tile bounds
+      p.stroke(255);
+      p.noFill();
+      p.rect(
+        i * TILE_SIZE + 1,
+        j * TILE_SIZE + 1,
+        TILE_SIZE - 2,
+        TILE_SIZE - 2
+      );
+
+      if ((i + j) % 2 == 0) {
+        p.line(
+          i * TILE_SIZE,
+          j * TILE_SIZE,
+          (i + 1) * TILE_SIZE,
+          (j + 1) * TILE_SIZE
         );
-
-        if ((i + j) % 2 == 0) {
-          p.line(
-            i * TILE_SIZE,
-            j * TILE_SIZE,
-            (i + 1) * TILE_SIZE,
-            (j + 1) * TILE_SIZE
-          );
-        } else {
-          p.line(
-            (i + 1) * TILE_SIZE,
-            j * TILE_SIZE,
-            i * TILE_SIZE,
-            (j + 1) * TILE_SIZE
-          );
-        }
+      } else {
+        p.line(
+          (i + 1) * TILE_SIZE,
+          j * TILE_SIZE,
+          i * TILE_SIZE,
+          (j + 1) * TILE_SIZE
+        );
       }
-    }
+    });
 
-    for (let i = 0; i < CANVAS_SIZE_TILES; i++) {
-      for (let j = 0; j < CANVAS_SIZE_TILES; j++) {
-        const tile1 = p.floor(p.random(TILE_COUNT));
-        const tile2 = p.floor(p.random(TILE_COUNT));
-        draw_tile(p, i, j, tile1, tile2);
-      }
-    }
+    griderator(CANVAS_SIZE_TILES, CANVAS_SIZE_TILES, (i, j) => {
+      const tile1 = p.floor(p.random(TILE_COUNT));
+      const tile2 = p.floor(p.random(TILE_COUNT));
+      draw_tile(p, i, j, tile1, tile2);
+    });
 
     p.pop();
   };

--- a/PentagTiling/PentagCell.js
+++ b/PentagTiling/PentagCell.js
@@ -1,3 +1,5 @@
+import { Index2D } from "../sketchlib/Grid.js";
+
 const SIDE_VERTICAL = 0;
 const SIDE_TOP = 1;
 const SIDE_TOP_DIAG = 2;
@@ -5,9 +7,8 @@ const SIDE_BOTTOM_DIAG = 3;
 const SIDE_BOTTOM = 4;
 
 export class PentagCell {
-  constructor(row, col) {
-    this.row = row;
-    this.col = col;
+  constructor(index) {
+    this.index = index;
 
     this.arc_type = undefined;
     this.arc_choices = [true, true, true, true, true];
@@ -49,43 +50,45 @@ export class PentagCell {
   }
 
   get_neighbor(side) {
+    const { i: row, j: col } = this.index;
     const col_direction = this.is_flipped ? -1 : 1;
 
     if (side === SIDE_VERTICAL) {
-      return [this.row, this.col - col_direction];
+      return new Index2D(row, col - col_direction);
     }
 
     if (side === SIDE_TOP) {
-      return [this.row - 1, this.col];
+      return this.index.up();
     }
 
     if (side === SIDE_TOP_DIAG) {
-      switch (this.col % 4) {
+      switch (col % 4) {
         case 0:
-          return [this.row - 1, this.col + 1];
+          return new Index2D(row - 1, col + 1);
         case 1:
-          return [this.row, this.col - 1];
+          return this.index.left();
         case 2:
-          return [this.row, this.col + 1];
+          return this.index.right();
         case 3:
-          return [this.row - 1, this.col - 1];
+          return new Index2D(row - 1, col - 1);
       }
     }
 
     if (side === SIDE_BOTTOM_DIAG) {
-      switch (this.col % 4) {
+      switch (col % 4) {
         case 0:
-          return [this.row, this.col + 1];
+          return this.index.right();
         case 1:
-          return [this.row + 1, this.col - 1];
+          return new Index2D(row + 1, col - 1);
         case 2:
-          return [this.row + 1, this.col + 1];
+          return new Index2D(row + 1, col + 1);
         case 3:
-          return [this.row, this.col - 1];
+          return this.index.left();
       }
     }
 
-    return [this.row + 1, this.col];
+    // SIDE_BOTTOM
+    return this.index.down();
   }
 
   get all_neighbors() {

--- a/PentagTiling/PentagCell.js
+++ b/PentagTiling/PentagCell.js
@@ -71,7 +71,7 @@ export class PentagCell {
     // If the tile is completely disconnected, render nothing
     const flags = [false, false, false, false, false];
 
-    if (!this.disconnected_side) {
+    if (this.disconnected_side === undefined) {
       return flags;
     }
 

--- a/PentagTiling/PentagGrid.js
+++ b/PentagTiling/PentagGrid.js
@@ -21,11 +21,12 @@ export class PentagGrid {
 
   clear_grid() {
     this.grid.fill((index) => {
-      if (!this.in_bounds(index)) {
+      const pentag_index = PentagIndex.from_index_2d(index);
+
+      if (!this.in_bounds(pentag_index)) {
         return undefined;
       }
 
-      const pentag_index = PentagIndex.from_index_2d(index);
       return new PentagCell(pentag_index);
     });
   }
@@ -99,8 +100,7 @@ export class PentagGrid {
       // To give an example, if the neighbor is in the up direction,
       // then its empty direction must not be in the down direction else
       // the arc in this tile will have nothing to connect to.
-      const opposite_side = (5 - side) % 5;
-      neighbor.arc_choices[opposite_side] = false;
+      neighbor.arc_choices[opposite_side(side)] = false;
 
       if (neighbor.arc_choice_count === 1) {
         one_option_left.push(neighbor);
@@ -119,8 +119,7 @@ export class PentagGrid {
         // To give an example, if the neighbor is in the up direction,
         // then its empty direction must not be in the down direction else
         // the arc in this tile will have nothing to connect to.
-        const opposite_side = (5 - side) % 5;
-        neighbor.arc_choices[opposite_side] = false;
+        neighbor.arc_choices[opposite_side(side)] = false;
 
         if (neighbor.arc_choice_count === 1) {
           one_option_left.push(neighbor);
@@ -133,14 +132,5 @@ export class PentagGrid {
     for (const cell of one_option_left) {
       this.select(cell.index);
     }
-  }
-
-  static needs_y_offset(col) {
-    // For every four columns, the second and third ones need to be shifted.
-    // In other words, if the columns are numbered 0, 1, 2, 3, we want 1 and 2.
-    //
-    // If we cycle this left (col - 1) === (col + 3) (mod 4), we have
-    // 3, 0, 1, 2, and now we can select out 0 or 1 by simple less than.
-    return (col + 3) % 4 < 2;
   }
 }

--- a/PentagTiling/PentagIndex.js
+++ b/PentagTiling/PentagIndex.js
@@ -1,0 +1,145 @@
+import { Index2D } from "../sketchlib/Grid.js";
+
+/**
+ * A Pentag tile has 5 sides. Even if the tile is flipped, they are referred
+ * to as follows:
+ *    ___top___
+ *   |         \
+ *   |        top diag
+ *   |           \
+ *  vertical      >
+ *   |           /
+ *   |        bottom diag
+ *   |__bottom_/
+ */
+export const PentagSide = {
+  VERTICAL: 0,
+  TOP: 1,
+  TOP_DIAG: 2,
+  BOTTOM_DIAG: 3,
+  BOTTOM: 4,
+  COUNT: 5,
+};
+Object.freeze(PentagSide);
+
+/**
+ * Get the opposite side of a tile edge. This is the edge of the neighbor
+ * tile in that direction.
+ * @param {PentagSide} side The side to get the opposite of
+ * @returns The opposite side
+ */
+export function opposite_side(side) {
+  switch (side) {
+    case PentagSide.VERTICAL:
+      return PentagSide.VERTICAL;
+    case PentagSide.TOP:
+      return PentagSide.BOTTOM;
+    case PentagSide.TOP_DIAG:
+      return PentagSide.BOTTOM_DIAG;
+    case PentagSide.BOTTOM:
+      return PentagSide.TOP;
+    case PentagSide.BOTTOM_DIAG:
+      return PentagSide.TOP_DIAG;
+  }
+}
+
+/**
+ * The pentag grid tiles have 4 possible orientations.
+ * facing forwards/backwards, and whether the column is staggered by half
+ * a row
+ *
+ * --->           <----
+ *      <--- --->
+ */
+export const PentagColumnType = {
+  FORWARD: 0,
+  FLIPPED_STAGGERED: 1,
+  FORWARD_STAGGERED: 2,
+  FLIPPED: 3,
+  COUNT: 4,
+};
+Object.freeze(PentagColumnType);
+
+/**
+ * An index for use for the PentagGrid. Since the grid is made up of
+ * pentagons, the math for computing neighbors is a bit different from Index2D
+ */
+export class PentagIndex {
+  constructor(row, col) {
+    this.row = row;
+    this.col = col;
+  }
+
+  to_index_2d() {
+    return new Index2D(this.row, this.col);
+  }
+
+  get column_type() {
+    // These correspond to the 4 enum values of PentagColumnType
+    return this.col % PentagColumnType.COUNT;
+  }
+
+  get is_flipped() {
+    const col_type = this.column_type;
+    return (
+      col_type === PentagColumnType.FLIPPED ||
+      col_type === PentagColumnType.FLIPPED_STAGGERED
+    );
+  }
+
+  get is_staggered() {
+    const col_type = this.column_type;
+    return (
+      col_type === PentagColumnType.FORWARD_STAGGERED ||
+      col_type === PentagColumnType.FLIPPED_STAGGERED
+    );
+  }
+
+  get_neighbor(side) {
+    const { row, col } = this;
+    const col_direction = this.is_flipped ? -1 : 1;
+    const col_type = this.column_type;
+
+    if (side === PentagSide.VERTICAL) {
+      return new PentagIndex(row, col - col_direction);
+    }
+
+    if (side === PentagSide.TOP) {
+      return new PentagIndex(row - 1, col);
+    }
+
+    if (side === PentagSide.TOP_DIAG) {
+      switch (col_type) {
+        case PentagColumnType.FORWARD:
+          return new PentagIndex(row - 1, col + 1);
+        case PentagColumnType.FLIPPED_STAGGERED:
+          return new PentagIndex(row, col - 1);
+        case PentagColumnType.FORWARD_STAGGERED:
+          return new PentagIndex(row, col + 1);
+        case PentagColumnType.FLIPPED:
+          return new PentagIndex(row - 1, col - 1);
+      }
+    }
+
+    if (side === PentagSide.BOTTOM_DIAG) {
+      switch (col_type) {
+        case PentagColumnType.FORWARD:
+          return new PentagIndex(row, col + 1);
+        case PentagColumnType.FLIPPED_STAGGERED:
+          return new PentagIndex(row + 1, col - 1);
+        case PentagColumnType.FORWARD_STAGGERED:
+          return new PentagIndex(row + 1, col + 1);
+        case PentagColumnType.FLIPPED:
+          return new PentagIndex(row, col - 1);
+      }
+    }
+
+    // PentagSide.SIDE_BOTTOM
+    return new PentagIndex(row + 1, col);
+  }
+
+  static from_index_2d(index) {
+    const { i, j } = index;
+    return new PentagIndex(i, j);
+  }
+}

--- a/PentagTiling/PentagIndex.test.js
+++ b/PentagTiling/PentagIndex.test.js
@@ -1,0 +1,122 @@
+import { describe, it, expect } from "vitest";
+import { Index2D } from "../sketchlib/Grid";
+import { PentagIndex, PentagSide } from "./PentagIndex";
+
+describe("PentagIndex", () => {
+  it("allows negative indices", () => {
+    const index = new PentagIndex(-1, -5);
+
+    expect(index.row).toBe(-1);
+    expect(index.col).toBe(-5);
+  });
+
+  it("to_index_2d throws for negative coordinates", () => {
+    const index = new PentagIndex(-1, 0);
+
+    expect(() => {
+      return index.to_index_2d();
+    }).toThrowError("i must be non-negative");
+  });
+
+  it("to_index_2d converts to Index2D for non-negative coordinates", () => {
+    const index = new PentagIndex(0, 1);
+
+    const result = index.to_index_2d();
+
+    const expected = new Index2D(0, 1);
+    expect(result).toEqual(expected);
+  });
+
+  it("get_neighbor for forward tile computes correct neighbors", () => {
+    const index = new PentagIndex(3, 0);
+
+    const result = [
+      index.get_neighbor(PentagSide.VERTICAL),
+      index.get_neighbor(PentagSide.TOP),
+      index.get_neighbor(PentagSide.TOP_DIAG),
+      index.get_neighbor(PentagSide.BOTTOM_DIAG),
+      index.get_neighbor(PentagSide.BOTTOM),
+    ];
+
+    const expected = [
+      new PentagIndex(3, -1),
+      new PentagIndex(2, 0),
+      new PentagIndex(2, 1),
+      new PentagIndex(3, 1),
+      new PentagIndex(4, 0),
+    ];
+    expect(result).toEqual(expected);
+  });
+
+  it("get_neighbor for flipped and staggered tile computes correct neighbors", () => {
+    const index = new PentagIndex(2, 1);
+
+    const result = [
+      index.get_neighbor(PentagSide.VERTICAL),
+      index.get_neighbor(PentagSide.TOP),
+      index.get_neighbor(PentagSide.TOP_DIAG),
+      index.get_neighbor(PentagSide.BOTTOM_DIAG),
+      index.get_neighbor(PentagSide.BOTTOM),
+    ];
+
+    const expected = [
+      new PentagIndex(2, 2),
+      new PentagIndex(1, 1),
+      new PentagIndex(2, 0),
+      new PentagIndex(3, 0),
+      new PentagIndex(3, 1),
+    ];
+    expect(result).toEqual(expected);
+  });
+
+  it("get_neighbor for forward staggered tile computes correct neighbors", () => {
+    const index = new PentagIndex(3, 2);
+
+    const result = [
+      index.get_neighbor(PentagSide.VERTICAL),
+      index.get_neighbor(PentagSide.TOP),
+      index.get_neighbor(PentagSide.TOP_DIAG),
+      index.get_neighbor(PentagSide.BOTTOM_DIAG),
+      index.get_neighbor(PentagSide.BOTTOM),
+    ];
+
+    const expected = [
+      new PentagIndex(3, 1),
+      new PentagIndex(2, 2),
+      new PentagIndex(3, 3),
+      new PentagIndex(4, 3),
+      new PentagIndex(4, 2),
+    ];
+    expect(result).toEqual(expected);
+  });
+
+  it("get_neighbor for flipped tile computes correct neighbors", () => {
+    const index = new PentagIndex(3, 3);
+
+    const result = [
+      index.get_neighbor(PentagSide.VERTICAL),
+      index.get_neighbor(PentagSide.TOP),
+      index.get_neighbor(PentagSide.TOP_DIAG),
+      index.get_neighbor(PentagSide.BOTTOM_DIAG),
+      index.get_neighbor(PentagSide.BOTTOM),
+    ];
+
+    const expected = [
+      new PentagIndex(3, 4),
+      new PentagIndex(2, 3),
+      new PentagIndex(2, 2),
+      new PentagIndex(3, 2),
+      new PentagIndex(4, 3),
+    ];
+    expect(result).toEqual(expected);
+  });
+
+  it("from_index_2d constructs a pentag index", () => {
+    const index = new Index2D(2, 1);
+
+    const result = PentagIndex.from_index_2d(index);
+
+    const expected = new PentagIndex(2, 1);
+    expect(result).toEqual(expected);
+  });
+});

--- a/PentagTiling/PentagTiling.js
+++ b/PentagTiling/PentagTiling.js
@@ -51,25 +51,19 @@ function get_pentag_point(index) {
 
   // For every four columns, the second and third ones need to be
   // shifted one square vertically
-  const offset_y = PentagGrid.needs_y_offset(col);
-  const y = 2 * row + Number(offset_y) + 1;
+  const y = 2 * row + Number(index.is_staggered) + 1;
 
   return [x, y];
 }
 
 function draw_pentag_cell(p, index) {
   const [x, y] = get_pentag_point(index);
-
-  // Every other column is a backwards pentag
-  const flipped = index.col % 2 === 1;
-
-  draw_pentag(p, x * SQUARE_SIZE, y * SQUARE_SIZE, flipped);
+  draw_pentag(p, x * SQUARE_SIZE, y * SQUARE_SIZE, index.is_flipped);
 }
 
 function draw_dot(p, index, radius) {
   const [x, y] = get_pentag_point(index);
-  const flipped = index.col % 2 === 1;
-  const x_direction = flipped ? -1.0 : 1.0;
+  const x_direction = index.is_flipped ? -1.0 : 1.0;
 
   const cx = (x - 1.5 * x_direction) * SQUARE_SIZE;
   const cy = y * SQUARE_SIZE;
@@ -78,8 +72,7 @@ function draw_dot(p, index, radius) {
 
 function draw_pentag_arcs(p, index, arc_enabled) {
   const [x, y] = get_pentag_point(index);
-  const flipped = index.col % 2 === 1;
-  const x_direction = flipped ? -1.0 : 1.0;
+  const x_direction = index.is_flipped ? -1.0 : 1.0;
 
   //    ____1____
   //   |         \

--- a/PrimroseField/PrimroseTile.js
+++ b/PrimroseField/PrimroseTile.js
@@ -1,4 +1,6 @@
 // the crosses at the corners of grid squares can't ever be smaller than 2x4 px
+import { griderator } from "../sketchlib/Grid.js";
+
 // else it stops looking like a cross and the illusion becomes less effective.
 const MIN_CROSS_WIDTH = 2;
 const MIN_CROSS_LENGTH = 4 * MIN_CROSS_WIDTH;
@@ -88,30 +90,28 @@ export class PrimroseTile {
       colors.cross_light,
     ];
 
-    for (let i = 0; i < GRID_SIZE - 1; i++) {
-      for (let j = 0; j < GRID_SIZE - 1; j++) {
-        const diag = invert_y ? i + (GRID_SIZE - 1 - j) : i + j;
-        const selected_color = colormap[diag % colormap.length];
-        this.gfx.fill(selected_color);
-        const center_x = (i + 1) * SQUARE_SIZE;
-        const center_y = (j + 1) * SQUARE_SIZE;
-        // horizontal stroke
-        this.gfx.rect(
-          center_x - CROSS_STROKE_LENGTH / 2,
-          center_y - CROSS_STROKE_THICKNESS / 2,
-          CROSS_STROKE_LENGTH,
-          CROSS_STROKE_THICKNESS
-        );
+    griderator(GRID_SIZE - 1, GRID_SIZE - 1, (i, j) => {
+      const diag = invert_y ? i + (GRID_SIZE - 1 - j) : i + j;
+      const selected_color = colormap[diag % colormap.length];
+      this.gfx.fill(selected_color);
+      const center_x = (i + 1) * SQUARE_SIZE;
+      const center_y = (j + 1) * SQUARE_SIZE;
+      // horizontal stroke
+      this.gfx.rect(
+        center_x - CROSS_STROKE_LENGTH / 2,
+        center_y - CROSS_STROKE_THICKNESS / 2,
+        CROSS_STROKE_LENGTH,
+        CROSS_STROKE_THICKNESS
+      );
 
-        // vertical stroke
-        this.gfx.rect(
-          center_x - CROSS_STROKE_THICKNESS / 2,
-          center_y - CROSS_STROKE_LENGTH / 2,
-          CROSS_STROKE_THICKNESS,
-          CROSS_STROKE_LENGTH
-        );
-      }
-    }
+      // vertical stroke
+      this.gfx.rect(
+        center_x - CROSS_STROKE_THICKNESS / 2,
+        center_y - CROSS_STROKE_LENGTH / 2,
+        CROSS_STROKE_THICKNESS,
+        CROSS_STROKE_LENGTH
+      );
+    });
   }
 
   make_graphics() {

--- a/sketchlib/Grid.js
+++ b/sketchlib/Grid.js
@@ -1,0 +1,117 @@
+export class Index1D {
+  constructor(i) {
+    if (i < 0) {
+      throw new Error("i must be non-negative");
+    }
+
+    this.i = i;
+  }
+
+  previous() {
+    if (this.i === 0) {
+      return undefined;
+    }
+
+    return new Index1D(this.i - 1);
+  }
+
+  next() {
+    return new Index1D(this.i + 1);
+  }
+}
+
+export class Index2D {
+  constructor(i, j) {
+    if (i < 0) {
+      throw new Error("i must be non-negative");
+    }
+    if (j < 0) {
+      throw new Error("j must be non-negative");
+    }
+
+    this.i = i;
+    this.j = j;
+  }
+
+  left() {
+    if (this.j === 0) {
+      return undefined;
+    }
+
+    return new Index2D(this.i, this.j - 1);
+  }
+
+  right() {
+    return new Index2D(this.i, this.j + 1);
+  }
+
+  down() {
+    return new Index2D(this.i + 1, this.j + 1);
+  }
+}
+
+/**
+ * 2D Grid class
+ */
+export class Grid {
+  constructor(rows, cols) {
+    this.rows = rows;
+    this.cols = cols;
+    // Preallocate the array
+    this.values = new Array(rows * cols);
+  }
+
+  *[Symbol.iterator]() {
+    for (let i = 0; i < this.rows; i++) {
+      for (let j = 0; j < this.cols; j++) {
+        yield this.values[i * this.cols + j];
+      }
+    }
+  }
+
+  set_1d(index, value) {
+    if (!(index instanceof Index1D)) {
+      throw new Error("index must be an Index1D object");
+    }
+
+    if (index.i >= this.values.length) {
+      throw new Error("index out of bounds");
+    }
+    this.values[index.i] = value;
+  }
+
+  get_1d(index) {
+    if (!(index instanceof Index1D)) {
+      throw new Error("index must be an Index1D object");
+    }
+
+    if (index.i >= this.values.length) {
+      throw new Error("index out of bounds");
+    }
+    return this.values[index.i];
+  }
+
+  set_2d(index, value) {
+    if (!(index instanceof Index2D)) {
+      throw new Error("index must be an Index2D object");
+    }
+
+    const i = index.i * this.cols + index.j;
+    if (i >= this.values.length) {
+      throw new Error("index out of bounds");
+    }
+    this.values[i] = value;
+  }
+
+  get_2d(index) {
+    if (!(index instanceof Index2D)) {
+      throw new Error("index must be an Index2D object");
+    }
+
+    const i = index.i * this.cols + index.j;
+    if (i >= this.values.length) {
+      throw new Error("index out of bounds");
+    }
+    return this.values[i];
+  }
+}

--- a/sketchlib/Grid.js
+++ b/sketchlib/Grid.js
@@ -55,6 +55,14 @@ export class Grid {
     }
   }
 
+  fill(callback) {
+    for (let i = 0; i < this.rows; i++) {
+      for (let j = 0; j < this.rows; j++) {
+        this.values[i * this.cols + j] = callback(new Index2D(i, j));
+      }
+    }
+  }
+
   set(index, value) {
     if (!(index instanceof Index2D)) {
       throw new Error("index must be an Index2D object");

--- a/sketchlib/Grid.js
+++ b/sketchlib/Grid.js
@@ -1,25 +1,3 @@
-export class Index1D {
-  constructor(i) {
-    if (i < 0) {
-      throw new Error("i must be non-negative");
-    }
-
-    this.i = i;
-  }
-
-  previous() {
-    if (this.i === 0) {
-      return undefined;
-    }
-
-    return new Index1D(this.i - 1);
-  }
-
-  next() {
-    return new Index1D(this.i + 1);
-  }
-}
-
 export class Index2D {
   constructor(i, j) {
     if (i < 0) {
@@ -77,29 +55,7 @@ export class Grid {
     }
   }
 
-  set_1d(index, value) {
-    if (!(index instanceof Index1D)) {
-      throw new Error("index must be an Index1D object");
-    }
-
-    if (index.i >= this.values.length) {
-      throw new Error("index out of bounds");
-    }
-    this.values[index.i] = value;
-  }
-
-  get_1d(index) {
-    if (!(index instanceof Index1D)) {
-      throw new Error("index must be an Index1D object");
-    }
-
-    if (index.i >= this.values.length) {
-      throw new Error("index out of bounds");
-    }
-    return this.values[index.i];
-  }
-
-  set_2d(index, value) {
+  set(index, value) {
     if (!(index instanceof Index2D)) {
       throw new Error("index must be an Index2D object");
     }
@@ -111,7 +67,7 @@ export class Grid {
     this.values[i] = value;
   }
 
-  get_2d(index) {
+  get(index) {
     if (!(index instanceof Index2D)) {
       throw new Error("index must be an Index2D object");
     }

--- a/sketchlib/Grid.js
+++ b/sketchlib/Grid.js
@@ -1,3 +1,26 @@
+/**
+ * Iterate over a 2D range of values, performing an action at each step.
+ * This is useful for drawing graphics arranged in a grid even if there's no
+ * data that needs to be stored.
+ *
+ * The range is iterated over in row-major order.
+ * @param {number} rows How many rows to iterate over
+ * @param {number} cols How many columns to iterate over
+ * @param {function(number, number)} callback The action to perform at cell (i, j)
+ */
+export function griderator(rows, cols, callback) {
+  for (let i = 0; i < rows; i++) {
+    for (let j = 0; j < cols; j++) {
+      callback(i, j);
+    }
+  }
+}
+
+/**
+ * 2D index (i, j) into a Grid. The indices must be non-negative.
+ * The naming convention assumes row-major order as this is common for 2D
+ * arrays.
+ */
 export class Index2D {
   constructor(i, j) {
     if (i < 0) {
@@ -11,6 +34,10 @@ export class Index2D {
     this.j = j;
   }
 
+  /**
+   * Get the coordinates of the left neighbor
+   * @returns {Index2D | undefined} The left neighbor, or undefined if at the edge of the grid
+   */
   left() {
     if (this.j === 0) {
       return undefined;
@@ -19,10 +46,18 @@ export class Index2D {
     return new Index2D(this.i, this.j - 1);
   }
 
+  /**
+   * Get the coordinates of the neighbor to the right
+   * @returns {Index2D} The neighbor to the right
+   */
   right() {
     return new Index2D(this.i, this.j + 1);
   }
 
+  /**
+   * Get the coordinates of the neighbor one row above
+   * @returns {Index2D | undefined} The upwards neighbor, or undefined if at the edge of the grid
+   */
   up() {
     if (this.i === 0) {
       return undefined;
@@ -31,21 +66,18 @@ export class Index2D {
     return new Index2D(this.i - 1, this.j);
   }
 
+  /**
+   * Get the coordinates of the neighbor one row below
+   * @returns {Index2D} The downwards neighbor
+   */
   down() {
     return new Index2D(this.i + 1, this.j + 1);
   }
 }
 
-export function griderator(rows, cols, callback) {
-  for (let i = 0; i < rows; i++) {
-    for (let j = 0; j < cols; j++) {
-      callback(i, j);
-    }
-  }
-}
-
 /**
- * 2D Grid class
+ * 2D array of values. It is indexed by Index2D objects rather than
+ * an integer index.
  */
 export class Grid {
   constructor(rows, cols) {
@@ -58,11 +90,15 @@ export class Grid {
   *[Symbol.iterator]() {
     yield* this.values;
   }
-
   entries() {
     return this.values.entries();
   }
 
+  /**
+   * Fill the grid by applying a callback function at every grid cell.
+   * @param {function(Index2D)} callback A function that takes an index and
+   * computes the value to store at that point in the grid.
+   */
   fill(callback) {
     for (let i = 0; i < this.rows; i++) {
       for (let j = 0; j < this.cols; j++) {
@@ -95,6 +131,12 @@ export class Grid {
     return this.values[i];
   }
 
+  /**
+   * Get the right neighbor of an index, performing bounds checking
+   * @param {Index2D} index The index to check
+   * @returns {Index2D | undefined} The right neighbor, or undefined if at the
+   * edge of the grid
+   */
   right(index) {
     if (index.j >= this.cols - 1) {
       return undefined;
@@ -103,6 +145,12 @@ export class Grid {
     return index.right();
   }
 
+  /**
+   * Get the neighbor one row below, performing bounds checking.
+   * @param {Index2D} index the index to check
+   * @returns {Index2D | undefined} The downwards neighbor, or undefined if at
+   * the edge of the grid
+   */
   down(index) {
     if (index.i >= this.rows - 1) {
       return undefined;

--- a/sketchlib/Grid.js
+++ b/sketchlib/Grid.js
@@ -80,7 +80,7 @@ export class Grid {
   }
 
   right(index) {
-    if (index.j >= this.cols) {
+    if (index.j >= this.cols - 1) {
       return undefined;
     }
 
@@ -88,7 +88,7 @@ export class Grid {
   }
 
   down(index) {
-    if (index.i >= this.rows) {
+    if (index.i >= this.rows - 1) {
       return undefined;
     }
 

--- a/sketchlib/Grid.js
+++ b/sketchlib/Grid.js
@@ -45,6 +45,14 @@ export class Index2D {
     return new Index2D(this.i, this.j + 1);
   }
 
+  up() {
+    if (this.i === 0) {
+      return undefined;
+    }
+
+    return new Index2D(this.i - 1, this.j);
+  }
+
   down() {
     return new Index2D(this.i + 1, this.j + 1);
   }
@@ -113,5 +121,21 @@ export class Grid {
       throw new Error("index out of bounds");
     }
     return this.values[i];
+  }
+
+  right(index) {
+    if (index.j >= this.cols) {
+      return undefined;
+    }
+
+    return index.right();
+  }
+
+  down(index) {
+    if (index.i >= this.rows) {
+      return undefined;
+    }
+
+    return index.down();
   }
 }

--- a/sketchlib/Grid.js
+++ b/sketchlib/Grid.js
@@ -36,6 +36,14 @@ export class Index2D {
   }
 }
 
+export function griderator(rows, cols, callback) {
+  for (let i = 0; i < rows; i++) {
+    for (let j = 0; j < cols; j++) {
+      callback(i, j);
+    }
+  }
+}
+
 /**
  * 2D Grid class
  */
@@ -48,16 +56,16 @@ export class Grid {
   }
 
   *[Symbol.iterator]() {
-    for (let i = 0; i < this.rows; i++) {
-      for (let j = 0; j < this.cols; j++) {
-        yield this.values[i * this.cols + j];
-      }
-    }
+    yield* this.values;
+  }
+
+  entries() {
+    return this.values.entries();
   }
 
   fill(callback) {
     for (let i = 0; i < this.rows; i++) {
-      for (let j = 0; j < this.rows; j++) {
+      for (let j = 0; j < this.cols; j++) {
         this.values[i * this.cols + j] = callback(new Index2D(i, j));
       }
     }

--- a/sketchlib/Grid.test.js
+++ b/sketchlib/Grid.test.js
@@ -13,6 +13,58 @@ describe("Index2D", () => {
       new Index2D(3, -1);
     }).toThrowError("j must be non-negative");
   });
+
+  it("left returns undefined at left boundary", () => {
+    const index = new Index2D(1, 0);
+
+    const result = index.left();
+
+    expect(result).toBeUndefined();
+  });
+
+  it("left computes left neighbor", () => {
+    const index = new Index2D(1, 5);
+
+    const result = index.left();
+
+    const expected = new Index2D(1, 4);
+    expect(result).toEqual(expected);
+  });
+
+  it("right computes right neighbor", () => {
+    const index = new Index2D(1, 5);
+
+    const result = index.right();
+
+    const expected = new Index2D(1, 6);
+    expect(result).toEqual(expected);
+  });
+
+  it("up returns undefined at top boundary", () => {
+    const index = new Index2D(0, 1);
+
+    const result = index.up();
+
+    expect(result).toBeUndefined();
+  });
+
+  it("up computes upwards neighbor", () => {
+    const index = new Index2D(1, 5);
+
+    const result = index.up();
+
+    const expected = new Index2D(0, 5);
+    expect(result).toEqual(expected);
+  });
+
+  it("down computes downwards neighbor", () => {
+    const index = new Index2D(1, 5);
+
+    const result = index.down();
+
+    const expected = new Index2D(2, 6);
+    expect(result).toEqual(expected);
+  });
 });
 
 describe("Grid", () => {
@@ -64,5 +116,43 @@ describe("Grid", () => {
     expect(() => {
       grid.get(new Index2D(4, 0));
     }).toThrowError("index out of bounds");
+  });
+
+  it("right with index at right edge returns undefined", () => {
+    const grid = new Grid(4, 4);
+    const on_edge = new Index2D(0, 3);
+
+    const result = grid.right(on_edge);
+
+    expect(result).toBeUndefined();
+  });
+
+  it("right with index in bounds returns right neighbor", () => {
+    const grid = new Grid(4, 4);
+    const index = new Index2D(0, 2);
+
+    const result = grid.right(index);
+
+    const expected = new Index2D(0, 3);
+    expect(result).toEqual(result);
+  });
+
+  it("down with index at bottom edge returns undefined", () => {
+    const grid = new Grid(4, 4);
+    const on_edge = new Index2D(3, 0);
+
+    const result = grid.down(on_edge);
+
+    expect(result).toBeUndefined();
+  });
+
+  it("down with index in bounds returns downward neighbor", () => {
+    const grid = new Grid(4, 4);
+    const index = new Index2D(2, 0);
+
+    const result = grid.right(index);
+
+    const expected = new Index2D(3, 0);
+    expect(result).toEqual(result);
   });
 });

--- a/sketchlib/Grid.test.js
+++ b/sketchlib/Grid.test.js
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "vitest";
-import { Grid, Index2D } from "./Grid";
+import { Grid, griderator, Index2D } from "./Grid";
 
 describe("Index2D", () => {
   it("throws for negative row", () => {
@@ -67,6 +67,25 @@ describe("Index2D", () => {
   });
 });
 
+describe("griderator", () => {
+  it("calls the callback for the given number of rows and columns", () => {
+    const result = [];
+    griderator(2, 3, (i, j) => {
+      result.push([i, j]);
+    });
+
+    const expected = [
+      [0, 0],
+      [0, 1],
+      [0, 2],
+      [1, 0],
+      [1, 1],
+      [1, 2],
+    ];
+    expect(result).toEqual(expected);
+  });
+});
+
 describe("Grid", () => {
   it("pre-allocates the array with undefined values", () => {
     const grid = new Grid(4, 5);
@@ -74,6 +93,26 @@ describe("Grid", () => {
     for (const entry of grid) {
       expect(entry).toBeUndefined();
     }
+  });
+
+  it("entries enumerates the entries", () => {
+    const grid = new Grid(2, 2);
+    grid.fill((index) => {
+      return index.i;
+    });
+
+    const result = [];
+    for (const x of grid.entries()) {
+      result.push(x);
+    }
+
+    const expected = [
+      [0, 0],
+      [1, 0],
+      [2, 1],
+      [3, 1],
+    ];
+    expect(result).toEqual(expected);
   });
 
   it("fill populates the array with the callback values", () => {

--- a/sketchlib/Grid.test.js
+++ b/sketchlib/Grid.test.js
@@ -1,13 +1,5 @@
 import { describe, it, expect } from "vitest";
-import { Grid, Index1D, Index2D } from "./Grid";
-
-describe("Index1D", () => {
-  it("throws for negative index", () => {
-    expect(() => {
-      new Index1D(-1);
-    }).toThrowError("i must be non-negative");
-  });
-});
+import { Grid, Index2D } from "./Grid";
 
 describe("Index2D", () => {
   it("throws for negative row", () => {
@@ -32,53 +24,11 @@ describe("Grid", () => {
     }
   });
 
-  it("set_1d with 2D index throws", () => {
-    const grid = new Grid(4, 4);
-
-    expect(() => {
-      grid.set_1d(new Index2D(1, 1), "foo");
-    }).toThrowError("index must be an Index1D object");
-  });
-
-  it("set_1d with 1D index throws for out of bounds", () => {
-    const grid = new Grid(4, 4);
-
-    expect(() => {
-      grid.set_1d(new Index1D(16), "oops");
-    }).toThrowError("index out of bounds");
-  });
-
-  it("set_1d sets value", () => {
-    const grid = new Grid(4, 4);
-    const index = new Index1D(3);
-
-    grid.set_1d(index, 3);
-    const result = grid.get_1d(index);
-
-    expect(result).toBe(3);
-  });
-
-  it("get_1d with 2D index throws", () => {
-    const grid = new Grid(4, 4);
-
-    expect(() => {
-      grid.get_1d(new Index2D(1, 1));
-    }).toThrowError("index must be an Index1D object");
-  });
-
-  it("get_1d with 1D index throws for out of bounds", () => {
-    const grid = new Grid(4, 4);
-
-    expect(() => {
-      grid.get_1d(new Index1D(16));
-    }).toThrowError("index out of bounds");
-  });
-
   it("set_2d with 1D index throws", () => {
     const grid = new Grid(4, 4);
 
     expect(() => {
-      grid.set_2d(new Index1D(2), "foo");
+      grid.set(2, "foo");
     }).toThrowError("index must be an Index2D object");
   });
 
@@ -86,7 +36,7 @@ describe("Grid", () => {
     const grid = new Grid(4, 4);
 
     expect(() => {
-      grid.set_2d(new Index2D(4, 0), "oops");
+      grid.set(new Index2D(4, 0), "oops");
     }).toThrowError("index out of bounds");
   });
 
@@ -94,25 +44,25 @@ describe("Grid", () => {
     const grid = new Grid(4, 4);
     const index = new Index2D(2, 1);
 
-    grid.set_2d(index, "foo");
-    const result = grid.get_2d(index);
+    grid.set(index, "foo");
+    const result = grid.get(index);
 
     expect(result).toBe("foo");
   });
 
-  it("get_2d with 1D index throws", () => {
+  it("get with 1D index throws", () => {
     const grid = new Grid(4, 4);
 
     expect(() => {
-      grid.get_2d(new Index1D(2));
+      grid.get(2);
     }).toThrowError("index must be an Index2D object");
   });
 
-  it("get_1d with 2D index throws for out of bounds", () => {
+  it("get with 2D index throws for out of bounds", () => {
     const grid = new Grid(4, 4);
 
     expect(() => {
-      grid.get_2d(new Index2D(4, 0));
+      grid.get(new Index2D(4, 0));
     }).toThrowError("index out of bounds");
   });
 });

--- a/sketchlib/Grid.test.js
+++ b/sketchlib/Grid.test.js
@@ -76,6 +76,20 @@ describe("Grid", () => {
     }
   });
 
+  it("fill populates the array with the callback values", () => {
+    const grid = new Grid(2, 2);
+
+    grid.fill((index) => {
+      const { i, j } = index;
+
+      return i * 2 + j;
+    });
+    const result = [...grid];
+
+    const expected = [0, 1, 2, 3];
+    expect(result).toEqual(expected);
+  });
+
   it("set_2d with 1D index throws", () => {
     const grid = new Grid(4, 4);
 

--- a/sketchlib/Grid.test.js
+++ b/sketchlib/Grid.test.js
@@ -1,0 +1,118 @@
+import { describe, it, expect } from "vitest";
+import { Grid, Index1D, Index2D } from "./Grid";
+
+describe("Index1D", () => {
+  it("throws for negative index", () => {
+    expect(() => {
+      new Index1D(-1);
+    }).toThrowError("i must be non-negative");
+  });
+});
+
+describe("Index2D", () => {
+  it("throws for negative row", () => {
+    expect(() => {
+      new Index2D(-1, 1);
+    }).toThrowError("i must be non-negative");
+  });
+
+  it("throws for negative column", () => {
+    expect(() => {
+      new Index2D(3, -1);
+    }).toThrowError("j must be non-negative");
+  });
+});
+
+describe("Grid", () => {
+  it("pre-allocates the array with undefined values", () => {
+    const grid = new Grid(4, 5);
+
+    for (const entry of grid) {
+      expect(entry).toBeUndefined();
+    }
+  });
+
+  it("set_1d with 2D index throws", () => {
+    const grid = new Grid(4, 4);
+
+    expect(() => {
+      grid.set_1d(new Index2D(1, 1), "foo");
+    }).toThrowError("index must be an Index1D object");
+  });
+
+  it("set_1d with 1D index throws for out of bounds", () => {
+    const grid = new Grid(4, 4);
+
+    expect(() => {
+      grid.set_1d(new Index1D(16), "oops");
+    }).toThrowError("index out of bounds");
+  });
+
+  it("set_1d sets value", () => {
+    const grid = new Grid(4, 4);
+    const index = new Index1D(3);
+
+    grid.set_1d(index, 3);
+    const result = grid.get_1d(index);
+
+    expect(result).toBe(3);
+  });
+
+  it("get_1d with 2D index throws", () => {
+    const grid = new Grid(4, 4);
+
+    expect(() => {
+      grid.get_1d(new Index2D(1, 1));
+    }).toThrowError("index must be an Index1D object");
+  });
+
+  it("get_1d with 1D index throws for out of bounds", () => {
+    const grid = new Grid(4, 4);
+
+    expect(() => {
+      grid.get_1d(new Index1D(16));
+    }).toThrowError("index out of bounds");
+  });
+
+  it("set_2d with 1D index throws", () => {
+    const grid = new Grid(4, 4);
+
+    expect(() => {
+      grid.set_2d(new Index1D(2), "foo");
+    }).toThrowError("index must be an Index2D object");
+  });
+
+  it("set_1d with 2D index throws for out of bounds", () => {
+    const grid = new Grid(4, 4);
+
+    expect(() => {
+      grid.set_2d(new Index2D(4, 0), "oops");
+    }).toThrowError("index out of bounds");
+  });
+
+  it("set_2d sets value", () => {
+    const grid = new Grid(4, 4);
+    const index = new Index2D(2, 1);
+
+    grid.set_2d(index, "foo");
+    const result = grid.get_2d(index);
+
+    expect(result).toBe("foo");
+  });
+
+  it("get_2d with 1D index throws", () => {
+    const grid = new Grid(4, 4);
+
+    expect(() => {
+      grid.get_2d(new Index1D(2));
+    }).toThrowError("index must be an Index2D object");
+  });
+
+  it("get_1d with 2D index throws for out of bounds", () => {
+    const grid = new Grid(4, 4);
+
+    expect(() => {
+      grid.get_2d(new Index2D(4, 0));
+    }).toThrowError("index out of bounds");
+  });
+});


### PR DESCRIPTION
Several sketches use 2D arrays, and so will the coral stuff I'm working on. I think it's about time to make a nice abstraction for this.

This PR:

- Adds a `Grid` class (2D array)
- Also adds an `Index2D` class for `i, j` coordinates within a 2D array
- Also adds a `griderator(rows, cols, (i, j) => {})` function for times when I want to iterate like a grid even if there's no array.