### PR TITLE
Fix image loading jank on index page

### DIFF
--- a/index.html
+++ b/index.html
@@ -26,10 +26,6 @@
         gap: 10px;
       }
 
-      .link img {
-        width: 250px;
-      }
-
       @media screen and (max-width: 500px) {
         .link {
           width: 250px;
@@ -53,6 +49,8 @@
         const img = document.createElement("img");
         img.setAttribute("alt", `view ${title} example`);
         img.setAttribute("src", thumbnail_url);
+        img.setAttribute("width", "250");
+        img.setAttribute("height", "350");
 
         const img_link = document.createElement("a");
         img_link.setAttribute("href", sketch_url);


### PR DESCRIPTION
After finding [this article about cumulative layout shift](https://web.dev/articles/optimize-cls), I learned what I've been doing wrong with images -- even with relative sizing, it's important to include the image width/height on the `<img>` itself so the browser knows how much space to reserve...