### PR TITLE
Prevent mobile scrolling behavior for sketches that need mouse drag events

### DIFF
--- a/Bezier/Bezier.js
+++ b/Bezier/Bezier.js
@@ -1,5 +1,6 @@
 import { fix_mouse_coords } from "../sketchlib/fix_mouse_coords.js";
 import { Point } from "../pga2d/objects.js";
+import { prevent_mobile_scroll } from "../sketchlib/prevent_mobile_scroll.js";
 
 let cp1 = Point.point(100, 240);
 let cp2 = Point.point(320, 100);
@@ -35,6 +36,7 @@ export const sketch = (p) => {
 
   p.setup = () => {
     canvas = p.createCanvas(500, 700).elt;
+    prevent_mobile_scroll(canvas);
   };
 
   p.draw = () => {

--- a/DifferentialGrowth/DifferentialGrowth.js
+++ b/DifferentialGrowth/DifferentialGrowth.js
@@ -4,9 +4,8 @@ import { DifferentialPolyline } from "./DifferentialPolyline.js";
 import { Color, Style } from "../sketchlib/Style.js";
 import { draw_primitive } from "../sketchlib/draw_primitive.js";
 import { Vector2 } from "./Vector2.js";
+import { HEIGHT, WIDTH } from "../sketchlib/dimensions.js";
 
-const WIDTH = 500;
-const HEIGHT = 700;
 const BOUNDS = new Rectangle(0, 0, WIDTH, HEIGHT);
 const QUADTREE = new Quadtree(BOUNDS);
 

--- a/DifferentialGrowth/DifferentialPolyline.js
+++ b/DifferentialGrowth/DifferentialPolyline.js
@@ -10,6 +10,7 @@ import { Vector2 } from "./Vector2.js";
 import { DifferentialNode, NEARBY_RADIUS } from "./DifferentialNode.js";
 import { Circle } from "./circle.js";
 import { mod } from "../sketchlib/mod.js";
+import { HEIGHT, WIDTH } from "../sketchlib/dimensions.js";
 
 const MAX_EDGE_LENGTH = 150;
 

--- a/HyperbolicConnections/HyperbolicConnections.js
+++ b/HyperbolicConnections/HyperbolicConnections.js
@@ -2,6 +2,7 @@ import { fix_mouse_coords } from "../sketchlib/fix_mouse_coords.js";
 import { Palette } from "./palette.js";
 import { Boundary, PAIR_COUNT } from "./boundaries.js";
 import { VERTEX_SHADER, FRAGMENT_SHADER } from "./shaders.js";
+import { prevent_mobile_scroll } from "../sketchlib/prevent_mobile_scroll.js";
 
 // The boundary pattern is generated randomly in chunks of the same
 // color. This is the largest number of boundary point pairs generated
@@ -72,6 +73,8 @@ export const sketch = (p) => {
     boundary.print();
 
     canvas = p.createCanvas(500, 700, p.WEBGL).elt;
+    prevent_mobile_scroll(canvas);
+
     poincare_shader = p.createShader(
       VERTEX_SHADER,
       FRAGMENT_SHADER(PAIR_COUNT)

--- a/Worm/Worm.js
+++ b/Worm/Worm.js
@@ -4,6 +4,7 @@ import { fix_mouse_coords } from "../sketchlib/fix_mouse_coords.js";
 import { draw_primitive } from "../sketchlib/draw_primitive.js";
 import { Point } from "../pga2d/objects.js";
 import { AnimatedWorm } from "./AnimatedWorm.js";
+import { prevent_mobile_scroll } from "../sketchlib/prevent_mobile_scroll.js";
 
 const INITIAL_POSITION = Point.point(WIDTH / 2, HEIGHT - 50);
 
@@ -14,6 +15,7 @@ export const sketch = (p) => {
   let mouse = INITIAL_POSITION;
   p.setup = () => {
     canvas = p.createCanvas(WIDTH, HEIGHT).elt;
+    prevent_mobile_scroll(canvas);
   };
 
   p.draw = () => {
@@ -24,7 +26,7 @@ export const sketch = (p) => {
     draw_primitive(p, WORM.render());
   };
 
-  p.mouseMoved = () => {
+  p.mouseMoved = (event) => {
     mouse = fix_mouse_coords(canvas, p.mouseX, p.mouseY);
   };
 

--- a/Worm/Worm.js
+++ b/Worm/Worm.js
@@ -26,7 +26,7 @@ export const sketch = (p) => {
     draw_primitive(p, WORM.render());
   };
 
-  p.mouseMoved = (event) => {
+  p.mouseMoved = () => {
     mouse = fix_mouse_coords(canvas, p.mouseX, p.mouseY);
   };
 

--- a/sketchlib/prevent_mobile_scroll.js
+++ b/sketchlib/prevent_mobile_scroll.js
@@ -10,6 +10,8 @@ export function prevent_mobile_scroll(canvas) {
     }
   };
 
+  // Since we're calling event.preventDefault(), we need to mark the event
+  // as not passive.
   const options = { passive: false };
   document.body.addEventListener("touchstart", callback, options);
   document.body.addEventListener("touchend", callback, options);

--- a/sketchlib/prevent_mobile_scroll.js
+++ b/sketchlib/prevent_mobile_scroll.js
@@ -1,0 +1,17 @@
+/**
+ * Based on https://kirkdev.blogspot.com/2020/10/prevent-browser-scrolling-while-drawing.html
+ * which in turn is based on https://stackoverflow.com/questions/49854201/html5-issue-canvas-scrolling-when-interacting-dragging-on-ios-11-3/51652248#51652248
+ * @param {HTMLCanvasElement} canvas The canvas to use
+ */
+export function prevent_mobile_scroll(canvas) {
+  const callback = (event) => {
+    if (event.target === canvas) {
+      event.preventDefault();
+    }
+  };
+
+  const options = { passive: false };
+  document.body.addEventListener("touchstart", callback, options);
+  document.body.addEventListener("touchend", callback, options);
+  document.body.addEventListener("touchmove", callback, options);
+}


### PR DESCRIPTION
For a few sketches, the mobile experience isn't great since the mouse drag events also scroll the page. 

I found a [fix for this](https://kirkdev.blogspot.com/2020/10/prevent-browser-scrolling-while-drawing.html) so I applied it to the sketches that need it. you add touch event handlers that filter out events for the `canvas` element.