### PR TITLE
Fix Mosaic Slider

### DIFF
--- a/MosaicSlider/PixelSwapPair.js
+++ b/MosaicSlider/PixelSwapPair.js
@@ -27,13 +27,13 @@ export class PixelSwapPair {
     this.style_b = style_b;
     this.position_a = position_a;
     this.position_b = position_b;
-    this.tween_ab = new Tween(
+    this.tween_ab = Tween.point(
       this.position_a,
       this.position_b,
       start_frame,
       duration_frames
     );
-    this.tween_ba = new Tween(
+    this.tween_ba = Tween.point(
       this.position_b,
       this.position_a,
       start_frame,


### PR DESCRIPTION
A recent PR updated the usage of the `Tween` class for inbetweening. I just needed to update the usage in Mosaic Slider