### PR TITLE
Fix imports for coral sketches

### DIFF
--- a/Coral/TileEditor/TileEditor.js
+++ b/Coral/TileEditor/TileEditor.js
@@ -4,7 +4,6 @@ import { CoralTile } from "../CoralTile.js";
 import { InteractiveTangent, InteractiveVertex } from "./interactive.js";
 import { find_splines } from "../find_splines.js";
 import { FlagSet } from "../../sketchlib/FlagSet.js";
-import { GridDirection } from "../../sketchlib/GridDiection.js";
 import { Style } from "../../sketchlib/Style.js";
 import {
   render_quad,
@@ -25,6 +24,7 @@ import {
   SPLINE_STYLE,
 } from "../styles.js";
 import { Color } from "../../sketchlib/Style.js";
+import { Direction } from "../../sketchlib/Direction.js";
 
 const WIDTH = 500;
 const HEIGHT = 700;
@@ -43,10 +43,7 @@ const CONNECTION_ORDER = [
 ];
 
 const TILES = SMALL_QUADS.map(({ i, j }, quad) => {
-  const connection_flags = new FlagSet(
-    CONNECTION_ORDER[i][j],
-    GridDirection.COUNT
-  );
+  const connection_flags = new FlagSet(CONNECTION_ORDER[i][j], Direction.COUNT);
   return new CoralTile(quad, connection_flags);
 });
 

--- a/Coral/rendering.js
+++ b/Coral/rendering.js
@@ -1,8 +1,8 @@
 import { Point } from "../pga2d/objects.js";
 import { LinePrimitive, RectPrimitive } from "../sketchlib/primitives.js";
-import { GridDirection } from "../sketchlib/GridDiection.js";
 import { Rect } from "./Rect.js";
 import { CoralTile } from "./CoralTile.js";
+import { Direction } from "../sketchlib/Direction.js";
 
 /**
  * Render the boundaries and cross-bars of a quad to uncolored geometry
@@ -41,7 +41,7 @@ export function render_tile_connections(tile) {
   const flags = tile.connection_flags;
   const center = quad.uv_to_world(Point.point(0.5, 0.5));
   const primitives = [];
-  for (let i = 0; i < GridDirection.COUNT; i++) {
+  for (let i = 0; i < Direction.COUNT; i++) {
     if (!flags.has_flag(i)) {
       continue;
     }
@@ -65,13 +65,13 @@ const WALLS = [
  * Render the walls of a maze (walls on sides of grid cells with no connections)
  *
  * @param {CoralTile} tile The tile to render
- * @returns {LinePrimitive} The lines representing wall segments.
+ * @returns {LinePrimitive[]} The lines representing wall segments.
  */
 export function render_tile_walls(tile) {
   const quad = tile.quad;
   const flags = tile.connection_flags;
   const primitives = [];
-  for (let i = 0; i < GridDirection.COUNT; i++) {
+  for (let i = 0; i < Direction.COUNT; i++) {
     if (flags.has_flag(i)) {
       continue;
     }


### PR DESCRIPTION
Looks like in merging things the other day, the coral editor didn't get the change of `GridDirection -> Direction`