### PR TITLE
Add options to the Style constructor

### DIFF
--- a/Anabaena/Anabaena.js
+++ b/Anabaena/Anabaena.js
@@ -31,13 +31,18 @@ const COLOR_CELL_S = Color.from_hex_code("#4cbac0");
 // dark sea green
 const COLOR_CELL_L = Color.from_hex_code("#419977");
 const CELL_THICKNESS = 20;
-const STYLE_CELL_S = new Style()
-  .with_stroke(COLOR_CELL_S)
-  .with_width(CELL_THICKNESS);
-const STYLE_CELL_L = new Style()
-  .with_stroke(COLOR_CELL_L)
-  .with_width(CELL_THICKNESS);
-const STYLE_ARROW = new Style().with_stroke(Color.BLACK).with_width(2);
+const STYLE_CELL_S = new Style({
+  stroke: COLOR_CELL_S,
+  width: CELL_THICKNESS,
+});
+const STYLE_CELL_L = new Style({
+  stroke: COLOR_CELL_L,
+  width: CELL_THICKNESS,
+});
+const STYLE_ARROW = new Style({
+  stroke: Color.BLACK,
+  width: 2,
+});
 
 class AnabaenaCatenula {
   constructor() {

--- a/Coral/TileEditor/TileEditor.js
+++ b/Coral/TileEditor/TileEditor.js
@@ -72,10 +72,10 @@ const SELECTION_ORDER = [...TANGENTS, ...VERTICES];
 const SPLINES = find_splines(TILES);
 
 // These styles are only used in this sketch
-export const HIGHLIGHT_STYLE = new Style().with_fill(new Color(0, 0, 255));
-export const VERTEX_STYLE = new Style().with_fill(new Color(255, 255, 0));
-export const TANGENT_TIP_STYLE = new Style().with_fill(new Color(0, 255, 0));
-export const TANGENT_STYLE = new Style().with_stroke(new Color(0, 255, 0));
+export const HIGHLIGHT_STYLE = new Style({ fill: Color.CYAN });
+export const VERTEX_STYLE = new Style({ fill: Color.YELLOW });
+export const TANGENT_TIP_STYLE = new Style({ fill: Color.GREEN });
+export const TANGENT_STYLE = new Style({ fill: Color.GREEN });
 
 function render_control_points(tiles) {
   const tangent_lines = [];

--- a/Coral/styles.js
+++ b/Coral/styles.js
@@ -1,9 +1,11 @@
 import { Style, Color } from "../sketchlib/Style.js";
-const THICK = new Style().with_width(4);
-
-export const GRID_STYLE = new Style()
-  .with_stroke(new Color(127, 127, 127))
-  .with_width(0.5);
+const THICK = new Style({
+  width: 4,
+});
+export const GRID_STYLE = new Style({
+  stroke: new Color(127, 127, 127),
+  width: 0.5,
+});
 export const WALL_STYLE = THICK.with_stroke(new Color(85, 59, 112));
 export const CONNECTION_STYLE = THICK.with_stroke(new Color(33, 41, 102));
 

--- a/DifferentialGrowth/DifferentialGrowth.js
+++ b/DifferentialGrowth/DifferentialGrowth.js
@@ -24,7 +24,7 @@ for (let i = 0; i < INITIAL_POINTS; i++) {
 const POLYLINE = new DifferentialPolyline(points, QUADTREE);
 const POLYLINE2 = new DifferentialPolyline(points2, QUADTREE);
 
-const BASE_STYLE = new Style().with_stroke(new Color(0, 0, 0)).with_width(2);
+const BASE_STYLE = new Style({ stroke: Color.BLACK, width: 2 });
 const STYLE_POLYLINE1 = BASE_STYLE.with_fill(new Color(255, 127, 0));
 const STYLE_POLYLINE2 = BASE_STYLE.with_fill(new Color(0, 127, 0));
 
@@ -90,10 +90,10 @@ export const sketch = (p) => {
 
     if (show_ref_geometry) {
       const poly1 = POLYLINE.make_polyline(
-        STYLE_POLYLINE1.with_stroke(new Color(255, 255, 255))
+        STYLE_POLYLINE1.with_stroke(Color.WHITE)
       );
       const poly2 = POLYLINE2.make_polyline(
-        STYLE_POLYLINE2.with_stroke(new Color(255, 255, 255))
+        STYLE_POLYLINE2.with_stroke(Color.WHITE)
       );
       draw_primitive(p, poly1);
       draw_primitive(p, poly2);

--- a/MosaicSlider/MosaicGrid.js
+++ b/MosaicSlider/MosaicGrid.js
@@ -15,7 +15,7 @@ const MARGIN_Y = (HEIGHT - ROWS * SQUARE_SIZE) / 2;
 const STRIDE = Point.direction(SQUARE_SIZE, SQUARE_SIZE);
 const CORNER = Point.point(MARGIN_X, MARGIN_Y);
 const SWAP_DURATION = sec_to_frames(1 / 16);
-const PIXEL_STYLE = new Style().with_stroke(Color.BLACK).with_width(2);
+const PIXEL_STYLE = new Style({ stroke: Color.BLACK, width: 2 });
 
 /**
  * Color each quadrant of the grid a different color
@@ -48,7 +48,7 @@ export class MosaicGrid {
     this.colors = colors;
     this.styles = colors.map((x) => PIXEL_STYLE.with_fill(x));
     // Add an additional style for hole pixels.
-    this.styles.push(new Style());
+    this.styles.push(Style.INVISIBLE);
 
     this.primitive = this.create_primitive();
     this.primitive_dirty = false;

--- a/PerspectiveRailroad/PerspectiveRailroad.js
+++ b/PerspectiveRailroad/PerspectiveRailroad.js
@@ -20,9 +20,9 @@ const BOTTOM_SIDE = new Line(0, 1, HEIGHT);
 const RAIL_WIDTH = 30;
 const RAIL_HEIGHT = 50;
 
-const DEFAULT_STYLE = new Style().with_stroke(new Color(0, 0, 0));
+const DEFAULT_STYLE = new Style({ stroke: Color.BLACK });
 const GROUND_STYLE = DEFAULT_STYLE.with_fill(new Color(135, 201, 162));
-const SKY_STYLE = new Style().with_fill(new Color(30, 173, 235));
+const SKY_STYLE = new Style({ fill: new Color(30, 173, 235) });
 const RAIL_STYLE = DEFAULT_STYLE.with_fill(new Color(71, 70, 69));
 const TIE_STYLE = DEFAULT_STYLE.with_fill(new Color(99, 59, 26));
 
@@ -81,7 +81,7 @@ const MAX_ITERATIONS = 500;
  * @param {Point} point_a The bottom left corner of the sidewalk
  * @param {Point} point_b The bottom right corner of the sidewalk. It must be at the same y-value as point_a.
  * @param {Point} vp Vanishing point where rectangles converge
- * @param {number1} vertical_spacing vertical spacing in px between the first two lines.
+ * @param {number} vertical_spacing vertical spacing in px between the first two lines.
  * @returns {object} An object with data representing the lines and points of the pattern.
  */
 function even_spaced_rectangles(point_a, point_b, vp, vertical_spacing) {

--- a/Worm/AnimatedWorm.js
+++ b/Worm/AnimatedWorm.js
@@ -28,12 +28,12 @@ const ROT90 = Motor.rotation(Point.ORIGIN, Math.PI / 2);
 const ROT45 = Motor.rotation(Point.ORIGIN, Math.PI / 4);
 const DEBUG_SHOW_SPINE = false;
 
-const COLOR_SPINE = new Color(255, 255, 255);
-const SPINE_STYLE = new Style().with_stroke(COLOR_SPINE);
-const CENTER_STYLE = new Style().with_fill(COLOR_SPINE);
-const WORM_STYLE = new Style()
-  .with_fill(new Color(255, 122, 151))
-  .with_stroke(new Color(127, 61, 76));
+const SPINE_STYLE = new Style({ stroke: Color.WHITE });
+const CENTER_STYLE = new Style({ fill: Color.WHITE });
+const WORM_STYLE = new Style({
+  fill: new Color(255, 122, 151),
+  stroke: new Color(127, 61, 76),
+});
 
 /**
  * A cute animated worm with googly eyes, animated with AnimationChain

--- a/Worm/GooglyEye.js
+++ b/Worm/GooglyEye.js
@@ -2,10 +2,8 @@ import { Point } from "../pga2d/objects.js";
 import { CirclePrimitive, GroupPrimitive } from "../sketchlib/primitives.js";
 import { Color, Style } from "../sketchlib/Style.js";
 
-const COLOR_SCLERA = new Color(255, 255, 255);
-const COLOR_PUPIL = new Color(0, 0, 0);
-const STYLE_SCLERA = new Style().with_fill(COLOR_SCLERA);
-const STYLE_PUPIL = new Style().with_fill(COLOR_PUPIL);
+const STYLE_SCLERA = new Style({ fill: Color.WHITE });
+const STYLE_PUPIL = new Style({ fill: Color.BLACK });
 
 export class GooglyEye {
   constructor(position, look_direction, sclera_radius, pupil_radius) {

--- a/lab/DoublePendulum/DoublePendulumSystem.js
+++ b/lab/DoublePendulum/DoublePendulumSystem.js
@@ -11,16 +11,11 @@ import { GeneralizedCoordinates } from "../lablib/VectorSpace.js";
 import { PI, TAU } from "../../sketchlib/math_consts.js";
 import { mod } from "../../sketchlib/mod.js";
 
-const STYLE_AXIS = new Style()
-  .with_stroke(new Color(255, 255, 255))
-  .with_width(2);
+const STYLE_AXIS = Style.DEFAULT_STROKE.with_width(2);
+const ARM_STYLE = STYLE_AXIS;
 
-const ARM_STYLE = new Style()
-  .with_stroke(new Color(255, 255, 255))
-  .with_width(2);
-
-const STYLE_PHASE1 = new Style().with_stroke(new Color(255, 255, 0));
-const STYLE_PHASE2 = new Style().with_stroke(new Color(0, 255, 255));
+const STYLE_PHASE1 = new Style({ stroke: Color.YELLOW });
+const STYLE_PHASE2 = new Style({ stroke: Color.CYAN });
 
 const PIXELS_PER_METER = 100;
 

--- a/lab/DoubleSpring/DoubleSpringSystem.js
+++ b/lab/DoubleSpring/DoubleSpringSystem.js
@@ -14,10 +14,10 @@ const X_METERS = Point.DIR_X.scale(PIXELS_PER_METER);
 const Y_METERS = Point.DIR_Y.scale(-PIXELS_PER_METER);
 const NUM_COILS = 10;
 
-const STYLE_AXIS = new Style().with_stroke(new Color(255, 255, 255));
-const STYLE_WALLS = new Style().with_stroke(new Color(255, 255, 255));
-const STYLE_PHASE1 = new Style().with_stroke(new Color(255, 255, 0));
-const STYLE_PHASE2 = new Style().with_stroke(new Color(0, 255, 255));
+const STYLE_AXIS = Style.DEFAULT_STROKE;
+const STYLE_WALLS = Style.DEFAULT_STROKE;
+const STYLE_PHASE1 = new Style({ stroke: Color.YELLOW });
+const STYLE_PHASE2 = new Style({ stroke: Color.CYAN });
 
 export class Spring {
   /**

--- a/sketchlib/AnimationChain.js
+++ b/sketchlib/AnimationChain.js
@@ -3,9 +3,8 @@ import { Motor } from "../pga2d/versors.js";
 import { GroupPrimitive, LinePrimitive, PointPrimitive } from "./primitives.js";
 import { Color, Style } from "./Style.js";
 
-const COLOR_SPINE = new Color(255, 255, 255);
-const SPINE_STYLE = new Style().with_stroke(COLOR_SPINE);
-const CENTER_STYLE = new Style().with_fill(COLOR_SPINE);
+const SPINE_STYLE = Style.DEFAULT_STROKE;
+const CENTER_STYLE = new Style({ fill: Color.WHITE });
 
 /**
  * A joint in an AnimationChain

--- a/sketchlib/Style.js
+++ b/sketchlib/Style.js
@@ -60,21 +60,45 @@ export class Color {
     return new Color(red, green, blue);
   }
 }
+// Basic 8 colors for quick prototyping. In practice, these colors are harsh
+// so for final sketches, pick colors more intentionally
 Color.BLACK = Object.freeze(new Color(0, 0, 0));
+Color.RED = Object.freeze(new Color(255, 0, 0));
+Color.GREEN = Object.freeze(new Color(0, 255, 0));
+Color.BLUE = Object.freeze(new Color(0, 0, 255));
+Color.YELLOW = Object.freeze(new Color(255, 255, 0));
+Color.MAGENTA = Object.freeze(new Color(255, 0, 255));
+Color.CYAN = Object.freeze(new Color(0, 255, 255));
+Color.WHITE = Object.freeze(new Color(255, 255, 255));
+
+/**
+ * @typedef {Object} StyleDescriptor
+ * @property {Color} [stroke] The stroke color
+ * @property {number} [width] The stroke width
+ * @property {Color} [fill] The fill color
+ */
 
 export class Style {
-  constructor() {
-    this.stroke = undefined;
-    this.fill = undefined;
-    this.stroke_width = 1;
+  /**
+   * Constructor
+   * @param {StyleDescriptor} options The options for the style
+   */
+  constructor(options) {
+    this.stroke = options.stroke;
+    this.fill = options.fill;
+    this.stroke_width = options.width ?? 1;
   }
 
+  /**
+   * Make a copy of this style.
+   * @returns {Style} A copy of the style
+   */
   clone() {
-    const result = new Style();
-    result.stroke = this.stroke;
-    result.fill = this.fill;
-    result.stroke_width = this.stroke_width;
-    return result;
+    return new Style({
+      stroke: this.stroke,
+      fill: this.fill,
+      width: this.stroke_width,
+    });
   }
 
   /**
@@ -88,15 +112,34 @@ export class Style {
     return result;
   }
 
+  /**
+   * Create a new style that's equivalent to this one but with a new fill color
+   * @param {Color} fill The new fill color
+   * @returns {Style} The new style
+   */
   with_fill(fill) {
     const result = this.clone();
     result.fill = fill;
     return result;
   }
 
+  /**
+   * Create a new style that's equivalent to this one but with a new stroke width
+   * @param {number} width The new stroke width
+   * @returns {Style} The new style
+   */
   with_width(width) {
     const result = this.clone();
     result.stroke_width = width;
     return result;
   }
 }
+
+Style.INVISIBLE = Object.freeze(new Style({}));
+Style.DEFAULT_STROKE = Object.freeze(new Style({ stroke: Color.WHITE }));
+Style.DEFAULT_FILL = Object.freeze(
+  new Style({ stroke: Color.from_hex_code("#6eb2e8") })
+);
+Style.DEFAULT_STROKE_FILL = Object.freeze(
+  Style.DEFAULT_FILL.with_stroke(Color.WHITE)
+);

--- a/sketchlib/Style.test.js
+++ b/sketchlib/Style.test.js
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "vitest";
-import { Color } from "./Style";
+import { Color, Style } from "./Style";
 
 describe("Color", () => {
   it("from_hex_code with invalid hex code throws", () => {
@@ -33,5 +33,60 @@ describe("Color", () => {
 
     const expected = new Color(0x0f, 0xab, 0x35);
     expect(result).toEqual(expected);
+  });
+});
+
+describe("Style", () => {
+  it("constructor with empty object returns transparent style", () => {
+    const style = new Style({});
+
+    expect(style.stroke).toBeUndefined();
+    expect(style.fill).toBeUndefined();
+    expect(style.stroke_width).toBe(1);
+  });
+
+  it("constructor configures style settings", () => {
+    const style = new Style({
+      stroke: Color.RED,
+      fill: Color.BLUE,
+      width: 4,
+    });
+
+    expect(style.stroke).toEqual(Color.RED);
+    expect(style.fill).toEqual(Color.BLUE);
+    expect(style.stroke_width).toBe(4);
+  });
+
+  it("with_stroke creates a new style with a different stroke color", () => {
+    const style = Style.DEFAULT_STROKE_FILL;
+
+    const result = style.with_stroke(Color.RED);
+
+    expect(result).not.toBe(style);
+    expect(result.stroke).toEqual(Color.RED);
+    expect(result.fill).toEqual(style.fill);
+    expect(result.stroke_width).toEqual(style.stroke_width);
+  });
+
+  it("with_fill creates a new style with a different fill color", () => {
+    const style = Style.DEFAULT_STROKE_FILL;
+
+    const result = style.with_fill(Color.RED);
+
+    expect(result).not.toBe(style);
+    expect(result.stroke).toEqual(style.stroke);
+    expect(result.fill).toEqual(Color.RED);
+    expect(result.stroke_width).toEqual(style.stroke_width);
+  });
+
+  it("with_width creates a new style with a different fill color", () => {
+    const style = Style.DEFAULT_STROKE_FILL;
+
+    const result = style.with_width(10);
+
+    expect(result).not.toBe(style);
+    expect(result.stroke).toEqual(style.stroke);
+    expect(result.fill).toEqual(style.fill);
+    expect(result.stroke_width).toEqual(10);
   });
 });


### PR DESCRIPTION
The `Style` class here was originally inspired by one I made in `math-notebook`. But this isn't Rust that doesn't have operator overloading. In JS, it's more typical to pass in an object with properties.

Now creating a style might look like this:

```js
new Style({
  stroke: Color.BLACK,
  fill: Color.RED,
  width: 4
});
```

I also added more color and style constants