### PR TITLE
Simplify configuring mouse events

### DIFF
--- a/lab/ButtonLab/ButtonLab.js
+++ b/lab/ButtonLab/ButtonLab.js
@@ -4,11 +4,11 @@ import { to_y_down } from "../../sketchlib/Direction.js";
 import { draw_primitive } from "../../sketchlib/draw_primitive.js";
 import { CirclePrimitive, GroupPrimitive } from "../../sketchlib/primitives.js";
 import { Style } from "../../sketchlib/Style.js";
-import { MouseHandler } from "../lablib/better_mouse_events.js";
+import { CanvasMouseHandler } from "../lablib/CanvasMouseHandler.js";
 import { DirectionalPad } from "../lablib/DirectionalPad.js";
 import { Rectangle } from "../lablib/Rectangle.js";
 
-const MOUSE = new MouseHandler();
+const MOUSE = new CanvasMouseHandler();
 const DPAD = new DirectionalPad(
   new Rectangle(Point.point(-2, 10), Point.direction(200, 200)),
   0.01

--- a/lab/ButtonLab/ButtonLab.js
+++ b/lab/ButtonLab/ButtonLab.js
@@ -6,14 +6,11 @@ import { fix_mouse_coords } from "../../sketchlib/fix_mouse_coords.js";
 import { prevent_mobile_scroll } from "../../sketchlib/prevent_mobile_scroll.js";
 import { CirclePrimitive, GroupPrimitive } from "../../sketchlib/primitives.js";
 import { Style } from "../../sketchlib/Style.js";
-import {
-  mouse_dragged,
-  mouse_pressed,
-  mouse_released,
-} from "../lablib/better_mouse_events.js";
+import { MouseHandler } from "../lablib/better_mouse_events.js";
 import { DirectionalPad } from "../lablib/DirectionalPad.js";
 import { Rectangle, SCREEN_RECT } from "../lablib/Rectangle.js";
 
+const MOUSE = new MouseHandler();
 const DPAD = new DirectionalPad(
   new Rectangle(Point.point(-2, 10), Point.direction(200, 200)),
   0.01
@@ -34,7 +31,7 @@ export const sketch = (p) => {
       document.getElementById("sketch-canvas")
     ).elt;
 
-    prevent_mobile_scroll(canvas);
+    MOUSE.setup(canvas);
   };
 
   function move_circle() {
@@ -60,39 +57,16 @@ export const sketch = (p) => {
     draw_primitive(p, scene);
   };
 
-  mouse_pressed(p, canvas, (input) => {
+  MOUSE.mouse_pressed(p, (input) => {
     DPAD.mouse_pressed(input.mouse_coords);
-  });
-
-  /*
-  mouse_dragged(p, canvas, (input) => {
-    DPAD.mouse_dragged(input);
   });
 
   p.mouseReleased = () => {
     // Even if the mouse is off the canvas, release the DPAD input
     DPAD.mouse_released();
   };
-  */
 
-  /*
-  p.mousePressed = () => {
-    const mouse = fix_mouse_coords(canvas, p.mouseX, p.mouseY);
-    if (!SCREEN_RECT.contains(mouse)) {
-      return;
-    }
-
-    DPAD.mouse_pressed(mouse);
-  };*/
-
-  /*
-  p.mouseDragged = () => {
-    const mouse = fix_mouse_coords(canvas, p.mouseX, p.mouseY);
-    if (!SCREEN_RECT.contains(mouse)) {
-      return;
-    }
-
-    DPAD.mouse_dragged(mouse);
-  };
-  */
+  MOUSE.mouse_dragged(p, (input) => {
+    DPAD.mouse_dragged(input);
+  });
 };

--- a/lab/ButtonLab/ButtonLab.js
+++ b/lab/ButtonLab/ButtonLab.js
@@ -6,11 +6,16 @@ import { fix_mouse_coords } from "../../sketchlib/fix_mouse_coords.js";
 import { prevent_mobile_scroll } from "../../sketchlib/prevent_mobile_scroll.js";
 import { CirclePrimitive, GroupPrimitive } from "../../sketchlib/primitives.js";
 import { Style } from "../../sketchlib/Style.js";
+import {
+  mouse_dragged,
+  mouse_pressed,
+  mouse_released,
+} from "../lablib/better_mouse_events.js";
 import { DirectionalPad } from "../lablib/DirectionalPad.js";
 import { Rectangle, SCREEN_RECT } from "../lablib/Rectangle.js";
 
 const DPAD = new DirectionalPad(
-  new Rectangle(Point.point(10, 10), Point.direction(200, 200)),
+  new Rectangle(Point.point(-2, 10), Point.direction(200, 200)),
   0.01
 );
 
@@ -55,6 +60,22 @@ export const sketch = (p) => {
     draw_primitive(p, scene);
   };
 
+  mouse_pressed(p, canvas, (input) => {
+    DPAD.mouse_pressed(input.mouse_coords);
+  });
+
+  /*
+  mouse_dragged(p, canvas, (input) => {
+    DPAD.mouse_dragged(input);
+  });
+
+  p.mouseReleased = () => {
+    // Even if the mouse is off the canvas, release the DPAD input
+    DPAD.mouse_released();
+  };
+  */
+
+  /*
   p.mousePressed = () => {
     const mouse = fix_mouse_coords(canvas, p.mouseX, p.mouseY);
     if (!SCREEN_RECT.contains(mouse)) {
@@ -62,8 +83,9 @@ export const sketch = (p) => {
     }
 
     DPAD.mouse_pressed(mouse);
-  };
+  };*/
 
+  /*
   p.mouseDragged = () => {
     const mouse = fix_mouse_coords(canvas, p.mouseX, p.mouseY);
     if (!SCREEN_RECT.contains(mouse)) {
@@ -72,13 +94,5 @@ export const sketch = (p) => {
 
     DPAD.mouse_dragged(mouse);
   };
-
-  p.mouseReleased = () => {
-    const mouse = fix_mouse_coords(canvas, p.mouseX, p.mouseY);
-    if (!SCREEN_RECT.contains(mouse)) {
-      return;
-    }
-
-    DPAD.mouse_released();
-  };
+  */
 };

--- a/lab/ButtonLab/ButtonLab.js
+++ b/lab/ButtonLab/ButtonLab.js
@@ -2,13 +2,11 @@ import { Point } from "../../pga2d/objects.js";
 import { WIDTH, HEIGHT, SCREEN_CENTER } from "../../sketchlib/dimensions.js";
 import { to_y_down } from "../../sketchlib/Direction.js";
 import { draw_primitive } from "../../sketchlib/draw_primitive.js";
-import { fix_mouse_coords } from "../../sketchlib/fix_mouse_coords.js";
-import { prevent_mobile_scroll } from "../../sketchlib/prevent_mobile_scroll.js";
 import { CirclePrimitive, GroupPrimitive } from "../../sketchlib/primitives.js";
 import { Style } from "../../sketchlib/Style.js";
 import { MouseHandler } from "../lablib/better_mouse_events.js";
 import { DirectionalPad } from "../lablib/DirectionalPad.js";
-import { Rectangle, SCREEN_RECT } from "../lablib/Rectangle.js";
+import { Rectangle } from "../lablib/Rectangle.js";
 
 const MOUSE = new MouseHandler();
 const DPAD = new DirectionalPad(

--- a/lab/ButtonLab/ButtonLab.js
+++ b/lab/ButtonLab/ButtonLab.js
@@ -10,7 +10,7 @@ import { Rectangle } from "../lablib/Rectangle.js";
 
 const MOUSE = new CanvasMouseHandler();
 const DPAD = new DirectionalPad(
-  new Rectangle(Point.point(-2, 10), Point.direction(200, 200)),
+  new Rectangle(Point.point(10, 10), Point.direction(200, 200)),
   0.01
 );
 

--- a/lab/lablib/CanvasMouseHandler.js
+++ b/lab/lablib/CanvasMouseHandler.js
@@ -9,7 +9,7 @@ import { SCREEN_RECT } from "./Rectangle.js";
 /**
  * Class that helps set up canvas events
  */
-export class MouseHandler {
+export class CanvasMouseHandler {
   constructor() {
     /**
      * @type {HTMLCanvasElement}

--- a/lab/lablib/CanvasMouseHandler.js
+++ b/lab/lablib/CanvasMouseHandler.js
@@ -7,7 +7,10 @@ import { SCREEN_RECT } from "./Rectangle.js";
  */
 
 /**
- * Class that helps set up canvas events
+ * Class that helps set up mouse events that detect whether the mouse is
+ * on the canvas or out of the canvas.
+ *
+ * This class directly interacts with a p5 sketch
  */
 export class CanvasMouseHandler {
   constructor() {

--- a/lab/lablib/DirectionalPad.js
+++ b/lab/lablib/DirectionalPad.js
@@ -7,6 +7,7 @@ import {
   VectorPrimitive,
 } from "../../sketchlib/primitives.js";
 import { Style } from "../../sketchlib/Style.js";
+import { MouseInCanvas, MouseInput } from "./MouseInput.js";
 import { Rectangle } from "./Rectangle.js";
 
 /**
@@ -93,18 +94,22 @@ export class DirectionalPad {
 
   /**
    * Mouse dragged handler
-   * @param {Point} point The mouse coordinates relative to the canvas in pixels
+   * @param {MouseInput} mouse_input The sanitized mouse input event
    */
-  mouse_dragged(point) {
-    if (this.rect.contains(point)) {
-      this.update_value(point);
-    } else {
+  mouse_dragged(mouse_input) {
+    if (
+      mouse_input.in_canvas === MouseInCanvas.NOT_IN_CANVAS ||
+      !this.rect.contains(mouse_input.mouse_coords)
+    ) {
       this.clear_value();
     }
+
+    this.update_value(mouse_input.mouse_coords);
   }
 
   /**
-   * Mouse released handler
+   * Mouse released handler - regardless of where the mouse is,
+   * release the D-pad buttons
    */
   mouse_released() {
     this.clear_value();

--- a/lab/lablib/DirectionalPad.js
+++ b/lab/lablib/DirectionalPad.js
@@ -102,9 +102,9 @@ export class DirectionalPad {
       !this.rect.contains(mouse_input.mouse_coords)
     ) {
       this.clear_value();
+    } else {
+      this.update_value(mouse_input.mouse_coords);
     }
-
-    this.update_value(mouse_input.mouse_coords);
   }
 
   /**

--- a/lab/lablib/MouseInput.js
+++ b/lab/lablib/MouseInput.js
@@ -1,0 +1,31 @@
+import { Point } from "../../pga2d/objects.js";
+
+/**
+ * @enum {number}
+ */
+export const MousePressed = {
+  NOT_PRESSED: 0,
+  PRESSED: 1,
+};
+
+/**
+ * @enum {number}
+ */
+export const MouseInCanvas = {
+  NOT_IN_CANVAS: 0,
+  IN_CANVAS: 1,
+};
+
+export class MouseInput {
+  /**
+   * Mouse input event
+   * @param {Point} mouse_coords A Point
+   * @param {MousePressed} pressed If the mouse is pressed
+   * @param {MouseInCanvas} in_canvas If the mouse is in the canvas
+   */
+  constructor(mouse_coords, pressed, in_canvas) {
+    this.mouse_coords = mouse_coords;
+    this.pressed = pressed;
+    this.in_canvas = in_canvas;
+  }
+}

--- a/lab/lablib/better_mouse_events.js
+++ b/lab/lablib/better_mouse_events.js
@@ -1,4 +1,5 @@
 import { fix_mouse_coords } from "../../sketchlib/fix_mouse_coords.js";
+import { prevent_mobile_scroll } from "../../sketchlib/prevent_mobile_scroll.js";
 import { MouseInCanvas, MouseInput, MousePressed } from "./MouseInput.js";
 import { SCREEN_RECT } from "./Rectangle.js";
 /**
@@ -6,106 +7,129 @@ import { SCREEN_RECT } from "./Rectangle.js";
  */
 
 /**
- * Create a better mouse pressed event that:
- * - uses fix_mouse_coords to adjust mouse coords even if the
- * - ignores events outside the canvas
- * - events in the canvas will cancel the browser default behavior since this
- * can interfere with the sketch. Events outside the canvas are passed through
- * as usual
- *
- * Note that this assumes the default canvas dimensions of WIDTH and HEIGHT
- * @param {any} p the p5.js element
- * @param {HTMLCanvasElement} canvas The canvas element
- * @param {MouseCallback} callback The callback to call when the mouse is pressed on the canvas
+ * Class that helps set up canvas events
  */
-export function mouse_pressed(p, canvas, callback) {
-  p.mousePressed = (/** @type {MouseEvent} */ e) => {
-    const mouse = fix_mouse_coords(canvas, p.mouseX, p.mouseY);
-    if (!SCREEN_RECT.contains(mouse)) {
-      return;
-    }
+export class MouseHandler {
+  constructor() {
+    /**
+     * @type {HTMLCanvasElement}
+     */
+    this.canvas = undefined;
+  }
 
-    e.preventDefault();
-    const input = new MouseInput(
-      mouse,
-      MousePressed.PRESSED,
-      MouseInCanvas.IN_CANVAS
-    );
-    callback(input);
-  };
-}
+  /**
+   * Store the canvas, and prevent mobile scrolling
+   * @param {HTMLCanvasElement} canvas The canvas element
+   */
+  setup(canvas) {
+    this.canvas = canvas;
+    prevent_mobile_scroll(canvas);
+  }
 
-/**
- * Similar to mouse_pressed but for the mouse released event
- * @param {any} p the p5.js element
- * @param {HTMLCanvasElement} canvas The canvas element
- * @param {MouseCallback} callback The callback to call when the mouse is pressed on the canvas
- */
-export function mouse_released(p, canvas, callback) {
-  p.mouseReleased = (/**@type {MouseEvent} */ e) => {
-    const mouse = fix_mouse_coords(canvas, p.mouseX, p.mouseY);
-    if (!SCREEN_RECT.contains(mouse)) {
-      return;
-    }
+  /**
+   * Create a better mouse pressed event that:
+   * - uses fix_mouse_coords to adjust mouse coords even if the
+   * - ignores events outside the canvas
+   * - events in the canvas will cancel the browser default behavior since this
+   * can interfere with the sketch. Events outside the canvas are passed through
+   * as usual
+   *
+   * Note that this assumes the default canvas dimensions of WIDTH and HEIGHT
+   * @param {any} p the p5.js element
+   * @param {MouseCallback} callback The callback to call when the mouse is pressed on the canvas
+   */
+  mouse_pressed(p, callback) {
+    p.mousePressed = (/** @type {MouseEvent} */ e) => {
+      const mouse = fix_mouse_coords(this.canvas, p.mouseX, p.mouseY);
+      if (!SCREEN_RECT.contains(mouse)) {
+        return;
+      }
 
-    e.preventDefault();
-    const input = new MouseInput(
-      mouse,
-      MousePressed.NOT_PRESSED,
-      MouseInCanvas.IN_CANVAS
-    );
-    callback(input);
-  };
-}
-
-/**
- * When the mouse is moved
- * - Always prevent the default behavior
- *
- * @param {any} p the p5.js element
- * @param {HTMLCanvasElement} canvas The canvas element
- * @param {MouseCallback} callback The callback to call when the mouse is moved on the canvas
- */
-export function mouse_moved(p, canvas, callback) {
-  p.mouseMoved = (/**@type {MouseEvent} */ e) => {
-    const mouse = fix_mouse_coords(canvas, p.mouseX, p.mouseY);
-    const in_canvas = SCREEN_RECT.contains(mouse);
-    if (in_canvas) {
       e.preventDefault();
-    }
+      const input = new MouseInput(
+        mouse,
+        MousePressed.PRESSED,
+        MouseInCanvas.IN_CANVAS
+      );
+      callback(input);
+    };
+  }
 
-    const in_canvas_state = in_canvas
-      ? MouseInCanvas.IN_CANVAS
-      : MouseInCanvas.NOT_IN_CANVAS;
+  /**
+   * Similar to mouse_pressed but for the mouse released event
+   * @param {any} p the p5.js element
+   *
+   * @param {MouseCallback} callback The callback to call when the mouse is pressed on the canvas
+   */
+  mouse_released(p, callback) {
+    p.mouseReleased = (/**@type {MouseEvent} */ e) => {
+      const mouse = fix_mouse_coords(this.canvas, p.mouseX, p.mouseY);
+      if (!SCREEN_RECT.contains(mouse)) {
+        return;
+      }
 
-    const input = new MouseInput(
-      mouse,
-      MousePressed.NOT_PRESSED,
-      in_canvas_state
-    );
-    callback(input);
-  };
-}
-
-/**
- * Similar to mouse_moved, but now the mouse is pressed
- * @param {any} p the p5.js element
- * @param {HTMLCanvasElement} canvas The canvas element
- * @param {MouseCallback} callback The callback to call when the mouse is dragged on the canvas
- */
-export function mouse_dragged(p, canvas, callback) {
-  p.mouseDragged = (/**@type {MouseEvent} */ e) => {
-    const mouse = fix_mouse_coords(canvas, p.mouseX, p.mouseY);
-    const in_canvas = SCREEN_RECT.contains(mouse);
-    if (in_canvas) {
       e.preventDefault();
-    }
+      const input = new MouseInput(
+        mouse,
+        MousePressed.NOT_PRESSED,
+        MouseInCanvas.IN_CANVAS
+      );
+      callback(input);
+    };
+  }
 
-    const in_canvas_state = in_canvas
-      ? MouseInCanvas.IN_CANVAS
-      : MouseInCanvas.NOT_IN_CANVAS;
+  /**
+   * When the mouse is moved
+   * - If the mouse is hovering over the canvas, prevent the default behavior
+   * - Always call the callback, but include the in-canvas state
+   *
+   * @param {any} p the p5.js element
+   * @param {MouseCallback} callback The callback to call when the mouse is moved on the canvas
+   */
+  mouse_moved(p, callback) {
+    p.mouseMoved = (/**@type {MouseEvent} */ e) => {
+      const mouse = fix_mouse_coords(this.canvas, p.mouseX, p.mouseY);
+      const in_canvas = SCREEN_RECT.contains(mouse);
+      if (in_canvas) {
+        e.preventDefault();
+      }
 
-    const input = new MouseInput(mouse, MousePressed.PRESSED, in_canvas_state);
-    callback(input);
-  };
+      const in_canvas_state = in_canvas
+        ? MouseInCanvas.IN_CANVAS
+        : MouseInCanvas.NOT_IN_CANVAS;
+
+      const input = new MouseInput(
+        mouse,
+        MousePressed.NOT_PRESSED,
+        in_canvas_state
+      );
+      callback(input);
+    };
+  }
+
+  /**
+   * Similar to mouse_moved, but now the mouse is pressed
+   * @param {any} p the p5.js element
+   * @param {MouseCallback} callback The callback to call when the mouse is dragged on the canvas
+   */
+  mouse_dragged(p, callback) {
+    p.mouseDragged = (/**@type {MouseEvent} */ e) => {
+      const mouse = fix_mouse_coords(this.canvas, p.mouseX, p.mouseY);
+      const in_canvas = SCREEN_RECT.contains(mouse);
+      if (in_canvas) {
+        e.preventDefault();
+      }
+
+      const in_canvas_state = in_canvas
+        ? MouseInCanvas.IN_CANVAS
+        : MouseInCanvas.NOT_IN_CANVAS;
+
+      const input = new MouseInput(
+        mouse,
+        MousePressed.PRESSED,
+        in_canvas_state
+      );
+      callback(input);
+    };
+  }
 }

--- a/lab/lablib/better_mouse_events.js
+++ b/lab/lablib/better_mouse_events.js
@@ -1,0 +1,111 @@
+import { fix_mouse_coords } from "../../sketchlib/fix_mouse_coords.js";
+import { MouseInCanvas, MouseInput, MousePressed } from "./MouseInput.js";
+import { SCREEN_RECT } from "./Rectangle.js";
+/**
+ * @typedef {function(MouseInput):void} MouseCallback
+ */
+
+/**
+ * Create a better mouse pressed event that:
+ * - uses fix_mouse_coords to adjust mouse coords even if the
+ * - ignores events outside the canvas
+ * - events in the canvas will cancel the browser default behavior since this
+ * can interfere with the sketch. Events outside the canvas are passed through
+ * as usual
+ *
+ * Note that this assumes the default canvas dimensions of WIDTH and HEIGHT
+ * @param {any} p the p5.js element
+ * @param {HTMLCanvasElement} canvas The canvas element
+ * @param {MouseCallback} callback The callback to call when the mouse is pressed on the canvas
+ */
+export function mouse_pressed(p, canvas, callback) {
+  p.mousePressed = (/** @type {MouseEvent} */ e) => {
+    const mouse = fix_mouse_coords(canvas, p.mouseX, p.mouseY);
+    if (!SCREEN_RECT.contains(mouse)) {
+      return;
+    }
+
+    e.preventDefault();
+    const input = new MouseInput(
+      mouse,
+      MousePressed.PRESSED,
+      MouseInCanvas.IN_CANVAS
+    );
+    callback(input);
+  };
+}
+
+/**
+ * Similar to mouse_pressed but for the mouse released event
+ * @param {any} p the p5.js element
+ * @param {HTMLCanvasElement} canvas The canvas element
+ * @param {MouseCallback} callback The callback to call when the mouse is pressed on the canvas
+ */
+export function mouse_released(p, canvas, callback) {
+  p.mouseReleased = (/**@type {MouseEvent} */ e) => {
+    const mouse = fix_mouse_coords(canvas, p.mouseX, p.mouseY);
+    if (!SCREEN_RECT.contains(mouse)) {
+      return;
+    }
+
+    e.preventDefault();
+    const input = new MouseInput(
+      mouse,
+      MousePressed.NOT_PRESSED,
+      MouseInCanvas.IN_CANVAS
+    );
+    callback(input);
+  };
+}
+
+/**
+ * When the mouse is moved
+ * - Always prevent the default behavior
+ *
+ * @param {any} p the p5.js element
+ * @param {HTMLCanvasElement} canvas The canvas element
+ * @param {MouseCallback} callback The callback to call when the mouse is moved on the canvas
+ */
+export function mouse_moved(p, canvas, callback) {
+  p.mouseMoved = (/**@type {MouseEvent} */ e) => {
+    const mouse = fix_mouse_coords(canvas, p.mouseX, p.mouseY);
+    const in_canvas = SCREEN_RECT.contains(mouse);
+    if (in_canvas) {
+      e.preventDefault();
+    }
+
+    const in_canvas_state = in_canvas
+      ? MouseInCanvas.IN_CANVAS
+      : MouseInCanvas.NOT_IN_CANVAS;
+
+    const input = new MouseInput(
+      mouse,
+      MousePressed.NOT_PRESSED,
+      in_canvas_state
+    );
+    callback(input);
+  };
+}
+
+/**
+ * Similar to mouse_moved, but now the mouse is pressed
+ * @param {any} p the p5.js element
+ * @param {HTMLCanvasElement} canvas The canvas element
+ * @param {MouseCallback} callback The callback to call when the mouse is dragged on the canvas
+ */
+export function mouse_dragged(p, canvas, callback) {
+  p.mouseDragged = (/**@type {MouseEvent} */ e) => {
+    const mouse = fix_mouse_coords(canvas, p.mouseX, p.mouseY);
+    const in_canvas = SCREEN_RECT.contains(mouse);
+    if (in_canvas) {
+      e.preventDefault();
+    }
+
+    const in_canvas_state = in_canvas
+      ? MouseInCanvas.IN_CANVAS
+      : MouseInCanvas.NOT_IN_CANVAS;
+
+    const input = new MouseInput(mouse, MousePressed.PRESSED, in_canvas_state);
+    callback(input);
+  };
+}


### PR DESCRIPTION
Often when I handle mouse input, I need to do several things

- Keep track of whether the button event was in the canvas or outside it
- Attach event handlers to avoid scrolling the canvas on mobile
- Given the way the canvas shrinks via CSS, there's some math to compensate for that
- I want to convert the mouse position to my `Point` type for convenience

I created a `MouseHandler` that does all this, in an opt-in manner. The sketch can configure these callbacks or not.

Right now this only impacts `ButtonLab`