### PR TITLE
Add Oklch color space

### DIFF
--- a/Anabaena/Anabaena.js
+++ b/Anabaena/Anabaena.js
@@ -8,12 +8,12 @@ import { LSystem } from "./LSystem.js";
 import { sec_to_frames, Tween } from "../sketchlib/Tween.js";
 import { AnimationChain, Joint } from "../sketchlib/AnimationChain.js";
 import {
-  CirclePrimitive,
   GroupPrimitive,
   LinePrimitive,
   VectorPrimitive,
 } from "../sketchlib/primitives.js";
-import { Color, Style } from "../sketchlib/Style.js";
+import { Style } from "../sketchlib/Style.js";
+import { Color } from "../sketchlib/Color.js";
 
 const INITIAL_POSITION = Point.point(WIDTH / 2, HEIGHT - 50);
 const MIN_BEND_ANGLE = (7 * Math.PI) / 8;

--- a/Coral/TileEditor/TileEditor.js
+++ b/Coral/TileEditor/TileEditor.js
@@ -23,7 +23,7 @@ import {
   CONNECTION_STYLE,
   SPLINE_STYLE,
 } from "../styles.js";
-import { Color } from "../../sketchlib/Style.js";
+import { Color } from "../../sketchlib/Color.js";
 import { Direction } from "../../sketchlib/Direction.js";
 
 const WIDTH = 500;

--- a/Coral/TileEditor/TileEditor.js
+++ b/Coral/TileEditor/TileEditor.js
@@ -72,7 +72,7 @@ const SPLINES = find_splines(TILES);
 export const HIGHLIGHT_STYLE = new Style({ fill: Color.CYAN });
 export const VERTEX_STYLE = new Style({ fill: Color.YELLOW });
 export const TANGENT_TIP_STYLE = new Style({ fill: Color.GREEN });
-export const TANGENT_STYLE = new Style({ fill: Color.GREEN });
+export const TANGENT_STYLE = new Style({ stroke: Color.GREEN, width: 1.5 });
 
 function render_control_points(tiles) {
   const tangent_lines = [];

--- a/Coral/styles.js
+++ b/Coral/styles.js
@@ -1,4 +1,5 @@
-import { Style, Color } from "../sketchlib/Style.js";
+import { Color } from "../sketchlib/Color.js";
+import { Style } from "../sketchlib/Style.js";
 const THICK = new Style({
   width: 4,
 });

--- a/DifferentialGrowth/DifferentialGrowth.js
+++ b/DifferentialGrowth/DifferentialGrowth.js
@@ -1,10 +1,11 @@
 import { Rectangle } from "./rectangle.js";
 import { Quadtree } from "./quadtree.js";
 import { DifferentialPolyline } from "./DifferentialPolyline.js";
-import { Color, Style } from "../sketchlib/Style.js";
+import { Style } from "../sketchlib/Style.js";
 import { draw_primitive } from "../sketchlib/draw_primitive.js";
 import { Vector2 } from "./Vector2.js";
 import { HEIGHT, WIDTH } from "../sketchlib/dimensions.js";
+import { Color } from "../sketchlib/Color.js";
 
 const BOUNDS = new Rectangle(0, 0, WIDTH, HEIGHT);
 const QUADTREE = new Quadtree(BOUNDS);

--- a/MosaicSlider/InteractiveMosaic.js
+++ b/MosaicSlider/InteractiveMosaic.js
@@ -1,6 +1,6 @@
 import { Point } from "../pga2d/objects.js";
 import { GroupPrimitive } from "../sketchlib/primitives.js";
-import { Color } from "../sketchlib/Style.js";
+import { Color } from "../sketchlib/Color.js";
 import { MosaicGrid } from "./MosaicGrid.js";
 
 const SliderState = {

--- a/MosaicSlider/MosaicGrid.js
+++ b/MosaicSlider/MosaicGrid.js
@@ -2,10 +2,11 @@ import { Point } from "../pga2d/objects.js";
 import { Grid, Index2D } from "../sketchlib/Grid.js";
 import { HEIGHT, WIDTH } from "../sketchlib/dimensions.js";
 import { GroupPrimitive, RectPrimitive } from "../sketchlib/primitives.js";
-import { Color, Style } from "../sketchlib/Style.js";
+import { Style } from "../sketchlib/Style.js";
 import { PixelSwapPair } from "./PixelSwapPair.js";
 import { in_bounds } from "../sketchlib/in_bounds.js";
 import { sec_to_frames } from "../sketchlib/Tween.js";
+import { Color } from "../sketchlib/Color.js";
 
 const ROWS = 16;
 const COLS = 16;

--- a/MosaicSlider/MosaicSlider.js
+++ b/MosaicSlider/MosaicSlider.js
@@ -1,5 +1,5 @@
 import { WIDTH, HEIGHT } from "../sketchlib/dimensions.js";
-import { Color } from "../sketchlib/Style.js";
+import { Color } from "../sketchlib/Color.js";
 import { draw_primitive } from "../sketchlib/draw_primitive.js";
 import { fix_mouse_coords } from "../sketchlib/fix_mouse_coords.js";
 import { InteractiveMosaic } from "./InteractiveMosaic.js";

--- a/PerspectiveRailroad/PerspectiveRailroad.js
+++ b/PerspectiveRailroad/PerspectiveRailroad.js
@@ -4,8 +4,9 @@ import {
   RectPrimitive,
   GroupPrimitive,
 } from "../sketchlib/primitives.js";
-import { Color, Style } from "../sketchlib/Style.js";
+import { Style } from "../sketchlib/Style.js";
 import { draw_primitive } from "../sketchlib/draw_primitive.js";
+import { Color } from "../sketchlib/Color.js";
 
 const WIDTH = 500;
 const HEIGHT = 700;

--- a/Worm/AnimatedWorm.js
+++ b/Worm/AnimatedWorm.js
@@ -7,7 +7,7 @@ import {
   PointPrimitive,
 } from "../sketchlib/primitives.js";
 import { Style } from "../sketchlib/Style.js";
-import { Color } from "../sketchlib/Style.js";
+import { Color } from "../sketchlib/Color.js";
 import { Motor } from "../pga2d/versors.js";
 import { AnimationChain, Joint } from "../sketchlib/AnimationChain.js";
 import { is_nearly } from "../sketchlib/is_nearly.js";

--- a/Worm/GooglyEye.js
+++ b/Worm/GooglyEye.js
@@ -1,6 +1,7 @@
 import { Point } from "../pga2d/objects.js";
+import { Color } from "../sketchlib/Color.js";
 import { CirclePrimitive, GroupPrimitive } from "../sketchlib/primitives.js";
-import { Color, Style } from "../sketchlib/Style.js";
+import { Style } from "../sketchlib/Style.js";
 
 const STYLE_SCLERA = new Style({ fill: Color.WHITE });
 const STYLE_PUPIL = new Style({ fill: Color.BLACK });

--- a/lab/ButtonLab/ButtonLab.js
+++ b/lab/ButtonLab/ButtonLab.js
@@ -3,12 +3,13 @@ import { WIDTH, HEIGHT, SCREEN_CENTER } from "../../sketchlib/dimensions.js";
 import { to_y_down } from "../../sketchlib/Direction.js";
 import { draw_primitive } from "../../sketchlib/draw_primitive.js";
 import { CirclePrimitive, GroupPrimitive } from "../../sketchlib/primitives.js";
-import { Color, Style } from "../../sketchlib/Style.js";
+import { Style } from "../../sketchlib/Style.js";
 import { CanvasMouseHandler } from "../lablib/CanvasMouseHandler.js";
 import { TouchDPad } from "../lablib/TouchDPad.js";
 import { Rectangle } from "../lablib/Rectangle.js";
 import { ButtonState, TouchButton } from "../lablib/TouchButton.js";
 import { ToggleButton, ToggleState } from "../lablib/ToggleButton.js";
+import { Color } from "../../sketchlib/Color.js";
 
 const MOUSE = new CanvasMouseHandler();
 const DPAD = new TouchDPad(

--- a/lab/DoublePendulum/DoublePendulumSystem.js
+++ b/lab/DoublePendulum/DoublePendulumSystem.js
@@ -5,11 +5,12 @@ import {
   LinePrimitive,
 } from "../../sketchlib/primitives.js";
 import { RungeKuttaIntegrator } from "../lablib/RungeKuttaIntegrator.js";
-import { Color, Style } from "../../sketchlib/Style.js";
+import { Style } from "../../sketchlib/Style.js";
 import { RingBuffer } from "../lablib/RingBuffer.js";
 import { GeneralizedCoordinates } from "../lablib/VectorSpace.js";
 import { PI, TAU } from "../../sketchlib/math_consts.js";
 import { mod } from "../../sketchlib/mod.js";
+import { Color } from "../../sketchlib/Color.js";
 
 const STYLE_AXIS = Style.DEFAULT_STROKE.with_width(2);
 const ARM_STYLE = STYLE_AXIS;

--- a/lab/DoubleSpring/DoubleSpring.js
+++ b/lab/DoubleSpring/DoubleSpring.js
@@ -83,7 +83,7 @@ export const sketch = (p) => {
       V_SCALE
     );
 
-    const phase_animations = SPRING_SYSTEMS.flatMap((system, i) => {
+    const phase_animations = SPRING_SYSTEMS.flatMap((system) => {
       return system.render_phase(phase_origin, X_SCALE, V_SCALE);
     });
 

--- a/lab/DoubleSpring/DoubleSpring.js
+++ b/lab/DoubleSpring/DoubleSpring.js
@@ -2,7 +2,6 @@ import { Point } from "../../pga2d/objects.js";
 import { WIDTH, HEIGHT } from "../../sketchlib/dimensions.js";
 import { draw_primitive } from "../../sketchlib/draw_primitive.js";
 import { GroupPrimitive } from "../../sketchlib/primitives.js";
-import { Style } from "../../sketchlib/Style.js";
 import { Oklch } from "../lablib/Oklch.js";
 import { DoubleSpringSystem, Spring } from "./DoubleSpringSystem.js";
 
@@ -14,20 +13,13 @@ const LIGHT_YELLOW = new Oklch(0.82, 0.1246, 93.18);
 const DARK_PURPLE = new Oklch(0.5, 0.1246, 285.88);
 const LIGHT_BLUE = new Oklch(0.76, 0.1246, 209.65);
 
-const PALETTE_A = [
-  DARK_ORANGE,
-  Oklch.lerp(DARK_ORANGE, LIGHT_YELLOW, 0.25),
-  Oklch.lerp(DARK_ORANGE, LIGHT_YELLOW, 0.5),
-  Oklch.lerp(DARK_ORANGE, LIGHT_YELLOW, 0.75),
-  LIGHT_YELLOW,
-];
+const PALETTE_A = Oklch.gradient(DARK_ORANGE, LIGHT_YELLOW, N);
 const PALETTE_B = Oklch.gradient(DARK_PURPLE, LIGHT_BLUE, N);
 
 const SPRING_CONSTANT = 5.0;
 const REST_LENGTH = 1.0;
 const BOB_MASS = 0.5;
 const BOB_WIDTH = 0.4;
-// All springs will be the same, I'm only varying the initial positions
 
 /**
  * Build a spring

--- a/lab/DoubleSpring/DoubleSpringSystem.js
+++ b/lab/DoubleSpring/DoubleSpringSystem.js
@@ -8,7 +8,6 @@ import { RungeKuttaIntegrator } from "../lablib/RungeKuttaIntegrator.js";
 import { Style } from "../../sketchlib/Style.js";
 import { RingBuffer } from "../lablib/RingBuffer.js";
 import { GeneralizedCoordinates } from "../lablib/VectorSpace.js";
-import { Color } from "../../sketchlib/Color.js";
 import { Oklch } from "../lablib/Oklch.js";
 
 const PIXELS_PER_METER = 100;

--- a/lab/DoubleSpring/DoubleSpringSystem.js
+++ b/lab/DoubleSpring/DoubleSpringSystem.js
@@ -5,9 +5,10 @@ import {
   RectPrimitive,
 } from "../../sketchlib/primitives.js";
 import { RungeKuttaIntegrator } from "../lablib/RungeKuttaIntegrator.js";
-import { Color, Style } from "../../sketchlib/Style.js";
+import { Style } from "../../sketchlib/Style.js";
 import { RingBuffer } from "../lablib/RingBuffer.js";
 import { GeneralizedCoordinates } from "../lablib/VectorSpace.js";
+import { Color } from "../../sketchlib/Color.js";
 
 const PIXELS_PER_METER = 100;
 const X_METERS = Point.DIR_X.scale(PIXELS_PER_METER);

--- a/lab/DoubleSpring/index.html
+++ b/lab/DoubleSpring/index.html
@@ -23,20 +23,31 @@
         <canvas id="sketch-canvas" width="500" height="700"></canvas>
       </div>
       <div class="description">
-        Notes:
+        <details>
+          <summary>Changelog (last update 2025-04-27)</summary>
+          <ul>
+            <li>
+              2025-04-27 - I tried using
+              <a href="https://oklch.com/">Oklch</a> color space to make
+              perceptually-uniform gradients. Here I'm trying this out by
+              picking the spring colors with a gradient.
+            </li>
+            <li>
+              2025-04-09 - I tried the idea of stacking springs side-by-side. It
+              looks like my choice of initial conditions aren't actually
+              producing chaotic behavior (It does however produce a pretty
+              graph!). That said, even a double pendulum has regions that are
+              more stable than others, see
+              <a href="https://youtu.be/n7JK4Ht8k8M?si=90l4qSCRF5SY0ccu"
+                >this video</a
+              >. it might be worth making a plot like that of position 2 vs
+              position 1 rather than this phase plot (velocity vs position) to
+              help explore this more.
+            </li>
+          </ul>
+        </details>
+        <p>Notes:</p>
         <ul>
-          <li>
-            UPDATE 2025-04-09 - I tried the idea of stacking springs
-            side-by-side. It looks like my choice of initial conditions aren't
-            actually producing chaotic behavior (It does however produce a
-            pretty graph!). That said, even a double pendulum has regions that
-            are more stable than others, see
-            <a href="https://youtu.be/n7JK4Ht8k8M?si=90l4qSCRF5SY0ccu"
-              >this video</a
-            >. it might be worth making a plot like that of position 2 vs
-            position 1 rather than this phase plot (velocity vs position) to
-            help explore this more.
-          </li>
           <li>
             Link to <a href="../DoublePendulum/">Double Pendulum</a>. Text will
             be similar to what was used on that page to link to this one.

--- a/lab/lablib/Oklch.js
+++ b/lab/lablib/Oklch.js
@@ -113,15 +113,21 @@ export class Oklch {
   }
 
   /**
-   * Compute a gradient
-   * @param {Oklch} start_color The first color in the gradient
-   * @param {Oklch} end_color The last color
-   * @param {number} num_steps How many gradient steps. E.g. 3 means the result will be an array of 3 colors. There must be at least 2 color steps
-   * @returns {Oklch[]} Interpolated colors including the start and end
+   * Compute a gradient from start_color to end_color
+   * @param {Oklch} start_color The first color in the gradient.
+   * @param {Oklch} end_color The last color in the gradient.
+   * @param {number} num_steps How many gradient steps. E.g. 3 means the result
+   * will be an array of 3 colors. If there is only a single step, the start
+   * color will be returned
+   * @returns {Oklch[]} Interpolated colors.
    */
   static gradient(start_color, end_color, num_steps) {
-    if (num_steps < 2) {
-      throw new Error("num_steps must be at least 2");
+    if (num_steps === 0) {
+      return [];
+    }
+
+    if (num_steps === 1) {
+      return [start_color];
     }
 
     const result = new Array(num_steps);

--- a/lab/lablib/Oklch.js
+++ b/lab/lablib/Oklch.js
@@ -1,6 +1,6 @@
-import { clamp } from "../../sketchlib/clamp.js"
-import { lerp } from "../../sketchlib/lerp.js"
-import { Color } from "../../sketchlib/Style.js"
+import { clamp } from "../../sketchlib/clamp.js";
+import { lerp } from "../../sketchlib/lerp.js";
+import { Color } from "../../sketchlib/Color.js";
 
 /**
  * Convert from linear color component to sRGB component
@@ -8,92 +8,91 @@ import { Color } from "../../sketchlib/Style.js"
  * @see https://bottosson.github.io/posts/colorwrong/#what-can-we-do%3F
  * or
  * @see https://en.wikipedia.org/wiki/SRGB#Transfer_function_(%22gamma%22)
- * 
+ *
  * @param {number} x The linear value
  * @returns {number} The nonlinear value
  */
 function linear_to_srgb(x) {
-    if (x >= 0.0031308)
-        return (1.055) * x ^ (1.0 / 2.4) - 0.055
-    else
-        return 12.92 * x
+  if (x >= 0.0031308) return (1.055 * x) ^ (1.0 / 2.4 - 0.055);
+  else return 12.92 * x;
 }
 
 export class Oklch {
-    /**
-     * OK Lightness, Chroma Hue color space. This color space has perceptually
-     * uniform lightness as you go around the color wheel, so it's helpful
-     * for creating palettes
-     * 
-     * @see https://bottosson.github.io/posts/oklab/
-     * @param {number} lightness The lightness value (0 = black, 1 = white)
-     * @param {number} chroma How pure of a hue. 0 is grey, the maximum value  
-     * @param {number} hue Angle around the color wheel from 0 to 360 degrees.
-     * @param {number} [alpha=1] The opacity in [0, 1]
-     */
-    constructor(lightness, chroma, hue, alpha) {
-        this.lightness = lightness
-        this.chroma = chroma
-        this.hue = hue
-        this.alpha = alpha ?? 1.0
-    }
+  /**
+   * OK Lightness, Chroma Hue color space. This color space has perceptually
+   * uniform lightness as you go around the color wheel, so it's helpful
+   * for creating palettes
+   *
+   * @see https://bottosson.github.io/posts/oklab/
+   * @param {number} lightness The lightness value (0 = black, 1 = white)
+   * @param {number} chroma How pure of a hue. 0 is grey, the maximum value
+   * @param {number} hue Angle around the color wheel from 0 to 360 degrees.
+   * @param {number} [alpha=1] The opacity in [0, 1]
+   */
+  constructor(lightness, chroma, hue, alpha) {
+    this.lightness = lightness;
+    this.chroma = chroma;
+    this.hue = hue;
+    this.alpha = alpha ?? 1.0;
+  }
 
-    to_srgb() {
-        const { lightness, chroma, hue, alpha } = this;
-        const hue_radians = hue * Math.PI / 180;
-        const a = chroma * Math.cos(hue_radians);
-        const b = chroma * Math.sin(hue_radians);
+  to_srgb() {
+    const { lightness, chroma, hue, alpha } = this;
+    const hue_radians = (hue * Math.PI) / 180;
+    const a = chroma * Math.cos(hue_radians);
+    const b = chroma * Math.sin(hue_radians);
 
-        // Find the nonlinear cone responses 
-        const l_ = lightness + 0.3963377774 * a + 0.2158037573 * b;
-        const m_ = lightness - 0.1055613458 * a - 0.0638541728 * b;
-        const s_ = lightness - 0.0894841775 * a - 1.2914855480 * b;
+    // Find the nonlinear cone responses
+    const l_ = lightness + 0.3963377774 * a + 0.2158037573 * b;
+    const m_ = lightness - 0.1055613458 * a - 0.0638541728 * b;
+    const s_ = lightness - 0.0894841775 * a - 1.291485548 * b;
 
-        // Undo the non-linearity
-        const l = l_ * l_ * l_;
-        const m = m_ * m_ * m_;
-        const s = s_ * s_ * s_;
+    // Undo the non-linearity
+    const l = l_ * l_ * l_;
+    const m = m_ * m_ * m_;
+    const s = s_ * s_ * s_;
 
-        // Convert to linear sRGB. This may go outside of [0, 1]
-        const linear_red = 4.0767416621 * l - 3.3077115913 * m + 0.2309699292 * s;
-        const linear_green = -1.2684380046 * l + 2.6097574011 * m - 0.3413193965 * s;
-        const linear_blue = -0.0041960863 * l - 0.7034186147 * m + 1.7076147010 * s;
+    // Convert to linear sRGB. This may go outside of [0, 1]
+    const linear_red = 4.0767416621 * l - 3.3077115913 * m + 0.2309699292 * s;
+    const linear_green =
+      -1.2684380046 * l + 2.6097574011 * m - 0.3413193965 * s;
+    const linear_blue = -0.0041960863 * l - 0.7034186147 * m + 1.707614701 * s;
 
-        // Convert to sRGB [0, 1] (some values may be out of range)
-        const s_red = linear_to_srgb(linear_red);
-        const s_green = linear_to_srgb(linear_green);
-        const s_blue = linear_to_srgb(linear_blue);
+    // Convert to sRGB [0, 1] (some values may be out of range)
+    const s_red = linear_to_srgb(linear_red);
+    const s_green = linear_to_srgb(linear_green);
+    const s_blue = linear_to_srgb(linear_blue);
 
-        // convert to [0, 255] as an integer (some values may be out of range)
-        const red255 = Math.round(255 * s_red);
-        const green255 = Math.round(255 * s_green);
-        const blue255 = Math.round(255 * s_blue);
-        const alpha255 = Math.round(255 * alpha);
+    // convert to [0, 255] as an integer (some values may be out of range)
+    const red255 = Math.round(255 * s_red);
+    const green255 = Math.round(255 * s_green);
+    const blue255 = Math.round(255 * s_blue);
+    const alpha255 = Math.round(255 * alpha);
 
-        // clamp values into range
-        return new Color(
-            clamp(red255, 0, 255),
-            clamp(green255, 0, 255),
-            clamp(blue255, 0, 255),
-            clamp(alpha255, 0, 255),
-        )
-    }
+    // clamp values into range
+    return new Color(
+      clamp(red255, 0, 255),
+      clamp(green255, 0, 255),
+      clamp(blue255, 0, 255),
+      clamp(alpha255, 0, 255)
+    );
+  }
 
-    /**
-     * Interpolate colors. This gives a perceptual blend
-     * @param {Oklch} a The first color 
-     * @param {Oklch} b The second color
-     * @param {number} t The interpolation amount 
-     * @returns {Oklch}
-     */
-    static lerp(a, b, t) {
-        const { lightness: al, chroma: ac, hue: ah, alpha: aa } = a;
-        const { lightness: bl, chroma: bc, hue: bh, alpha: ba } = b;
+  /**
+   * Interpolate colors. This gives a perceptual blend
+   * @param {Oklch} a The first color
+   * @param {Oklch} b The second color
+   * @param {number} t The interpolation amount
+   * @returns {Oklch}
+   */
+  static lerp(a, b, t) {
+    const { lightness: al, chroma: ac, hue: ah, alpha: aa } = a;
+    const { lightness: bl, chroma: bc, hue: bh, alpha: ba } = b;
 
-        const lightness = lerp(al, bl, t);
-        const chroma = lerp(ac, bc, t);
-        const hue = lerp(ah, bh, t);
-        const alpha = lerp(aa, ba, t);
-        return new Oklch(lightness, chroma, hue, alpha);
-    }
+    const lightness = lerp(al, bl, t);
+    const chroma = lerp(ac, bc, t);
+    const hue = lerp(ah, bh, t);
+    const alpha = lerp(aa, ba, t);
+    return new Oklch(lightness, chroma, hue, alpha);
+  }
 }

--- a/lab/lablib/Oklch.js
+++ b/lab/lablib/Oklch.js
@@ -75,7 +75,7 @@ export class Oklch {
             clamp(red255, 0, 255),
             clamp(green255, 0, 255),
             clamp(blue255, 0, 255),
-            //clamp(alpha255, 0, 255),
+            clamp(alpha255, 0, 255),
         )
     }
 

--- a/lab/lablib/Oklch.js
+++ b/lab/lablib/Oklch.js
@@ -44,7 +44,8 @@ export class Oklch {
    * @returns {Oklch} The new color
    */
   adjust_lightness(delta) {
-    return new Oklch(this.lightness + delta, this.chroma, this.hue, this.alpha);
+    const l = clamp(this.lightness + delta, 0, 1);
+    return new Oklch(l, this.chroma, this.hue, this.alpha);
   }
 
   to_srgb() {

--- a/lab/lablib/Oklch.js
+++ b/lab/lablib/Oklch.js
@@ -1,0 +1,99 @@
+import { clamp } from "../../sketchlib/clamp.js"
+import { lerp } from "../../sketchlib/lerp.js"
+import { Color } from "../../sketchlib/Style.js"
+
+/**
+ * Convert from linear color component to sRGB component
+ * this is the standard sRGB transform
+ * @see https://bottosson.github.io/posts/colorwrong/#what-can-we-do%3F
+ * or
+ * @see https://en.wikipedia.org/wiki/SRGB#Transfer_function_(%22gamma%22)
+ * 
+ * @param {number} x The linear value
+ * @returns {number} The nonlinear value
+ */
+function linear_to_srgb(x) {
+    if (x >= 0.0031308)
+        return (1.055) * x ^ (1.0 / 2.4) - 0.055
+    else
+        return 12.92 * x
+}
+
+export class Oklch {
+    /**
+     * OK Lightness, Chroma Hue color space. This color space has perceptually
+     * uniform lightness as you go around the color wheel, so it's helpful
+     * for creating palettes
+     * 
+     * @see https://bottosson.github.io/posts/oklab/
+     * @param {number} lightness The lightness value (0 = black, 1 = white)
+     * @param {number} chroma How pure of a hue. 0 is grey, the maximum value  
+     * @param {number} hue Angle around the color wheel from 0 to 360 degrees.
+     * @param {number} [alpha=1] The opacity in [0, 1]
+     */
+    constructor(lightness, chroma, hue, alpha) {
+        this.lightness = lightness
+        this.chroma = chroma
+        this.hue = hue
+        this.alpha = alpha ?? 1.0
+    }
+
+    to_srgb() {
+        const { lightness, chroma, hue, alpha } = this;
+        const hue_radians = hue * Math.PI / 180;
+        const a = chroma * Math.cos(hue_radians);
+        const b = chroma * Math.sin(hue_radians);
+
+        // Find the nonlinear cone responses 
+        const l_ = lightness + 0.3963377774 * a + 0.2158037573 * b;
+        const m_ = lightness - 0.1055613458 * a - 0.0638541728 * b;
+        const s_ = lightness - 0.0894841775 * a - 1.2914855480 * b;
+
+        // Undo the non-linearity
+        const l = l_ * l_ * l_;
+        const m = m_ * m_ * m_;
+        const s = s_ * s_ * s_;
+
+        // Convert to linear sRGB. This may go outside of [0, 1]
+        const linear_red = 4.0767416621 * l - 3.3077115913 * m + 0.2309699292 * s;
+        const linear_green = -1.2684380046 * l + 2.6097574011 * m - 0.3413193965 * s;
+        const linear_blue = -0.0041960863 * l - 0.7034186147 * m + 1.7076147010 * s;
+
+        // Convert to sRGB [0, 1] (some values may be out of range)
+        const s_red = linear_to_srgb(linear_red);
+        const s_green = linear_to_srgb(linear_green);
+        const s_blue = linear_to_srgb(linear_blue);
+
+        // convert to [0, 255] as an integer (some values may be out of range)
+        const red255 = Math.round(255 * s_red);
+        const green255 = Math.round(255 * s_green);
+        const blue255 = Math.round(255 * s_blue);
+        const alpha255 = Math.round(255 * alpha);
+
+        // clamp values into range
+        return new Color(
+            clamp(red255, 0, 255),
+            clamp(green255, 0, 255),
+            clamp(blue255, 0, 255),
+            //clamp(alpha255, 0, 255),
+        )
+    }
+
+    /**
+     * Interpolate colors. This gives a perceptual blend
+     * @param {Oklch} a The first color 
+     * @param {Oklch} b The second color
+     * @param {number} t The interpolation amount 
+     * @returns {Oklch}
+     */
+    static lerp(a, b, t) {
+        const { lightness: al, chroma: ac, hue: ah, alpha: aa } = a;
+        const { lightness: bl, chroma: bc, hue: bh, alpha: ba } = b;
+
+        const lightness = lerp(al, bl, t);
+        const chroma = lerp(ac, bc, t);
+        const hue = lerp(ah, bh, t);
+        const alpha = lerp(aa, ba, t);
+        return new Oklch(lightness, chroma, hue, alpha);
+    }
+}

--- a/lab/lablib/Oklch.js
+++ b/lab/lablib/Oklch.js
@@ -38,6 +38,15 @@ export class Oklch {
     this.alpha = alpha ?? 1.0;
   }
 
+  /**
+   * Adjust the lightness component, returning a new color
+   * @param {number} delta How much to increase (+) or decrease (-) the lightness
+   * @returns {Oklch} The new color
+   */
+  adjust_lightness(delta) {
+    return new Oklch(this.lightness + delta, this.chroma, this.hue, this.alpha);
+  }
+
   to_srgb() {
     // convert Oklch -> Oklab
     const { lightness, chroma, hue, alpha } = this;
@@ -101,5 +110,26 @@ export class Oklch {
     const hue = lerp(ah, bh, t);
     const alpha = lerp(aa, ba, t);
     return new Oklch(lightness, chroma, hue, alpha);
+  }
+
+  /**
+   * Compute a gradient
+   * @param {Oklch} start_color The first color in the gradient
+   * @param {Oklch} end_color The last color
+   * @param {number} num_steps How many gradient steps. E.g. 3 means the result will be an array of 3 colors. There must be at least 2 color steps
+   * @returns {Oklch[]} Interpolated colors including the start and end
+   */
+  static gradient(start_color, end_color, num_steps) {
+    if (num_steps < 2) {
+      throw new Error("num_steps must be at least 2");
+    }
+
+    const result = new Array(num_steps);
+    for (let i = 0; i < num_steps; i++) {
+      const t = i / (num_steps - 1);
+      result[i] = Oklch.lerp(start_color, end_color, t);
+    }
+
+    return result;
   }
 }

--- a/lab/lablib/Oklch.js
+++ b/lab/lablib/Oklch.js
@@ -13,8 +13,10 @@ import { Color } from "../../sketchlib/Color.js";
  * @returns {number} The nonlinear value
  */
 function linear_to_srgb(x) {
-  if (x >= 0.0031308) return (1.055 * x) ^ (1.0 / 2.4 - 0.055);
-  else return 12.92 * x;
+  if (x >= 0.0031308) {
+    return Math.pow(1.055 * x, 1.0 / 2.4) - 0.055;
+  }
+  return 12.92 * x;
 }
 
 export class Oklch {
@@ -37,6 +39,7 @@ export class Oklch {
   }
 
   to_srgb() {
+    // convert Oklch -> Oklab
     const { lightness, chroma, hue, alpha } = this;
     const hue_radians = (hue * Math.PI) / 180;
     const a = chroma * Math.cos(hue_radians);
@@ -86,6 +89,10 @@ export class Oklch {
    * @returns {Oklch}
    */
   static lerp(a, b, t) {
+    if (t < 0 || t > 1) {
+      throw new Error("t must be in [0, 1]");
+    }
+
     const { lightness: al, chroma: ac, hue: ah, alpha: aa } = a;
     const { lightness: bl, chroma: bc, hue: bh, alpha: ba } = b;
 

--- a/lab/lablib/Oklch.js
+++ b/lab/lablib/Oklch.js
@@ -19,13 +19,16 @@ function linear_to_srgb(x) {
   return 12.92 * x;
 }
 
+/**
+ * OK Lightness, Chroma Hue color space. This color space has perceptually
+ * uniform lightness as you go around the color wheel, so it's helpful
+ * for creating palettes
+ *
+ * @see https://bottosson.github.io/posts/oklab/
+ */
 export class Oklch {
   /**
-   * OK Lightness, Chroma Hue color space. This color space has perceptually
-   * uniform lightness as you go around the color wheel, so it's helpful
-   * for creating palettes
-   *
-   * @see https://bottosson.github.io/posts/oklab/
+   * Constructor
    * @param {number} lightness The lightness value (0 = black, 1 = white)
    * @param {number} chroma How pure of a hue. 0 is grey, the maximum value
    * @param {number} hue Angle around the color wheel from 0 to 360 degrees.

--- a/lab/lablib/Oklch.test.js
+++ b/lab/lablib/Oklch.test.js
@@ -10,6 +10,44 @@ describe("Oklch", () => {
     expect(color).toEqual(expected);
   });
 
+  describe("adjust_lightness", () => {
+    it("with positive delta increases brightness", () => {
+      const color = new Oklch(0.5, 0.1, 300);
+
+      const result = color.adjust_lightness(0.1);
+
+      const expected = new Oklch(0.6, 0.1, 300);
+      expect(result).toEqual(expected);
+    });
+
+    it("with negative delta decreases brightness", () => {
+      const color = new Oklch(0.5, 0.1, 300);
+
+      const result = color.adjust_lightness(-0.1);
+
+      const expected = new Oklch(0.4, 0.1, 300);
+      expect(result).toEqual(expected);
+    });
+
+    it("clamps negative value", () => {
+      const color = new Oklch(0.5, 0.1, 300);
+
+      const result = color.adjust_lightness(-0.8);
+
+      const expected = new Oklch(0, 0.1, 300);
+      expect(result).toEqual(expected);
+    });
+
+    it("clamps out of range value", () => {
+      const color = new Oklch(0.5, 0.1, 300);
+
+      const result = color.adjust_lightness(0.8);
+
+      const expected = new Oklch(1, 0.1, 300);
+      expect(result).toEqual(expected);
+    });
+  });
+
   // NOTE: oklch.com uses the npm module culori which has slightly different
   // conversion coefficients than in the blog post... so I don't really
   // have a good source of truth. So these tests are to catch regressions.

--- a/lab/lablib/Oklch.test.js
+++ b/lab/lablib/Oklch.test.js
@@ -1,0 +1,126 @@
+import { describe, it, expect } from "vitest";
+import { Oklch } from "./Oklch.js";
+import { Color } from "../../sketchlib/Color.js";
+
+describe("Oklch", () => {
+  it("constructor without alpha sets alpha to 1", () => {
+    const color = new Oklch(0.7, 0.1, 300);
+
+    const expected = new Oklch(0.7, 0.1, 300, 1);
+    expect(color).toEqual(expected);
+  });
+
+  // NOTE: oklch.com uses the npm module culori which has slightly different
+  // conversion coefficients than in the blog post... so I don't really
+  // have a good source of truth. So these tests are to catch regressions.
+  describe("to_srgb", () => {
+    it("oklch(0, 0, 0) = black", () => {
+      const black = new Oklch(0, 0, 0);
+
+      const result = black.to_srgb();
+
+      const expected = new Color(0, 0, 0);
+      expect(result).toEqual(expected);
+    });
+
+    it("oklch(1, 0, 0) = white", () => {
+      const white = new Oklch(1, 0, 0);
+
+      const result = white.to_srgb();
+
+      const expected = new Color(247, 247, 247);
+      expect(result).toEqual(expected);
+    });
+
+    it("oklch(0.6, 0, 0) = half grey", () => {
+      // Note that srgb is nonlinear given human perception of light,
+      // so the lightness here is > 0.5
+      const medium_grey = new Oklch(0.6, 0, 0);
+
+      const result = medium_grey.to_srgb();
+
+      const expected = new Color(124, 124, 124);
+      expect(result).toEqual(expected);
+    });
+
+    it("converts color (1)", () => {
+      // Blue color picked via https://oklch.com/#0.75,0.1,220,100
+      const color = new Oklch(0.75, 0.1, 220);
+
+      const result = color.to_srgb();
+
+      const expected = new Color(88, 183, 211);
+      expect(result).toEqual(expected);
+    });
+
+    it("converts color (2)", () => {
+      // desaturated maroon via https://oklch.com/#0.5,0.05,30,100
+      const color = new Oklch(0.5, 0.05, 30);
+
+      const result = color.to_srgb();
+
+      // Note: Oklch.com gives
+      // #7d5952 is (125, 89, 82) which is slightly off
+      const expected = new Color(121, 86, 79);
+      expect(result).toEqual(expected);
+    });
+  });
+
+  describe("lerp", () => {
+    it("with t < 0 throws", () => {
+      const a = new Oklch(0.4, 0.05, 300, 0);
+      const b = new Oklch(0.8, 0.1, 100, 1);
+      expect(() => {
+        return Oklch.lerp(a, b, -1);
+      }).toThrowError("must be in [0, 1]");
+    });
+
+    it("with t=0 returns a", () => {
+      const a = new Oklch(0.7, 0.1, 300);
+      const b = new Oklch(0.7, 0.1, 25);
+
+      const result = Oklch.lerp(a, b, 0);
+
+      expect(result).toEqual(a);
+    });
+
+    it("with t between 0 and 1 returns  mix of a and b", () => {
+      const a = new Oklch(0.4, 0.05, 300, 0);
+      const b = new Oklch(0.8, 0.1, 100, 1);
+
+      const result = Oklch.lerp(a, b, 0.25);
+
+      // lightness = 3/4 * 0.4 + 1/4 * 0.8 = 0.5
+      // chroma = 3/4 * 0.05 + 1/4 * 0.1 = 0.0625
+      // hue = 3/4 * 300 + 1/4 * 100 = 250
+      // alpha = 3/4 * 0 + 1/4 * 1 = 0.25
+      const expected = new Oklch(0.5, 0.0625, 250, 0.25);
+      expect(result).toEqual(expected);
+    });
+
+    it("with t=1 returns b", () => {
+      const a = new Oklch(0.7, 0.1, 300);
+      const b = new Oklch(0.7, 0.1, 25);
+
+      const result = Oklch.lerp(a, b, 1);
+
+      expect(result).toEqual(b);
+    });
+
+    it("with a=b returns a", () => {
+      const a = new Oklch(0.7, 0.1, 300);
+
+      const result = Oklch.lerp(a, a, 0.25);
+
+      expect(result).toEqual(a);
+    });
+
+    it("with t > 1 throws", () => {
+      const a = new Oklch(0.4, 0.05, 300, 0);
+      const b = new Oklch(0.8, 0.1, 100, 1);
+      expect(() => {
+        return Oklch.lerp(a, b, 2);
+      }).toThrowError("must be in [0, 1]");
+    });
+  });
+});

--- a/lab/lablib/Oklch.test.js
+++ b/lab/lablib/Oklch.test.js
@@ -118,9 +118,65 @@ describe("Oklch", () => {
     it("with t > 1 throws", () => {
       const a = new Oklch(0.4, 0.05, 300, 0);
       const b = new Oklch(0.8, 0.1, 100, 1);
+
       expect(() => {
         return Oklch.lerp(a, b, 2);
       }).toThrowError("must be in [0, 1]");
+    });
+  });
+
+  describe("gradient", () => {
+    it("with 0 steps returns empty array", () => {
+      const a = new Oklch(0.4, 0.1, 300);
+      const b = new Oklch(0.8, 0.1, 300);
+
+      const result = Oklch.gradient(a, b, 0);
+
+      expect(result).toEqual([]);
+    });
+
+    it("with 1 step returns start color", () => {
+      const a = new Oklch(0.4, 0.1, 300);
+      const b = new Oklch(0.8, 0.1, 300);
+
+      const result = Oklch.gradient(a, b, 1);
+
+      expect(result).toEqual([a]);
+    });
+
+    it("with 2 steps returns start and end color", () => {
+      const a = new Oklch(0.4, 0.1, 300);
+      const b = new Oklch(0.8, 0.1, 300);
+
+      const result = Oklch.gradient(a, b, 2);
+
+      expect(result).toEqual([a, b]);
+    });
+
+    it("with 3 steps returns start, end and 50 percent mix", () => {
+      const a = new Oklch(0.3, 0.1, 100);
+      const b = new Oklch(0.4, 0.1, 300);
+
+      const result = Oklch.gradient(a, b, 3);
+
+      const expected_mid = new Oklch(0.35, 0.1, 200);
+      expect(result).toEqual([a, expected_mid, b]);
+    });
+
+    it("with several steps produces gradient", () => {
+      const a = new Oklch(0, 0, 0);
+      const b = new Oklch(1, 0.25, 100);
+
+      const result = Oklch.gradient(a, b, 5);
+
+      const expected = [
+        new Oklch(0, 0, 0),
+        new Oklch(0.25, 0.0625, 25),
+        new Oklch(0.5, 0.125, 50),
+        new Oklch(0.75, 0.1875, 75),
+        new Oklch(1, 0.25, 100),
+      ];
+      expect(result).toEqual(expected);
     });
   });
 });

--- a/lab/lablib/ToggleButton.js
+++ b/lab/lablib/ToggleButton.js
@@ -1,6 +1,7 @@
 import { Point } from "../../pga2d/objects.js";
+import { Color } from "../../sketchlib/Color.js";
 import { GroupPrimitive, RectPrimitive } from "../../sketchlib/primitives.js";
-import { Color, Style } from "../../sketchlib/Style.js";
+import { Style } from "../../sketchlib/Style.js";
 import { Rectangle } from "./Rectangle.js";
 import { ButtonState, TouchButton } from "./TouchButton.js";
 

--- a/lab/lablib/TouchButton.js
+++ b/lab/lablib/TouchButton.js
@@ -1,6 +1,7 @@
 import { Point } from "../../pga2d/objects.js";
+import { Color } from "../../sketchlib/Color.js";
 import { GroupPrimitive, RectPrimitive } from "../../sketchlib/primitives.js";
-import { Color, Style } from "../../sketchlib/Style.js";
+import { Style } from "../../sketchlib/Style.js";
 import { Rectangle } from "./Rectangle.js";
 
 /**

--- a/sketchlib/AnimationChain.js
+++ b/sketchlib/AnimationChain.js
@@ -1,7 +1,8 @@
 import { Point } from "../pga2d/objects.js";
 import { Motor } from "../pga2d/versors.js";
+import { Color } from "./Color.js";
 import { GroupPrimitive, LinePrimitive, PointPrimitive } from "./primitives.js";
-import { Color, Style } from "./Style.js";
+import { Style } from "./Style.js";
 
 const SPINE_STYLE = Style.DEFAULT_STROKE;
 const CENTER_STYLE = new Style({ fill: Color.WHITE });

--- a/sketchlib/Color.js
+++ b/sketchlib/Color.js
@@ -1,0 +1,77 @@
+const REGEX_HEX_COLOR = /^#?[0-9A-Fa-f]{6}$/;
+
+/**
+ * Format a u8 as a 2-digit hex number with leading 0s as needed
+ * @param {number} value_u8
+ */
+function format_hex_u8(value_u8) {
+    const hex_value = value_u8.toString(16);
+    if (hex_value.length === 1) {
+        return `0${hex_value}`;
+    }
+
+    return hex_value;
+}
+
+/**
+ * sRGBA color with values in the range [0, 255]
+ */
+export class Color {
+    /**
+     * Constructor
+     * @param {number} r The red component from 0 to 255
+     * @param {number} g The green component from 0 to 255
+     * @param {number} b The blue component from 0 to 255
+     * @param {number} [a = 255] the alpha component from 0 to 255
+     */
+    constructor(r, g, b, a) {
+        this.r = r;
+        this.g = g;
+        this.b = b;
+        this.a = a ?? 255;
+    }
+
+    /**
+     * Convert a color to a CSS color code
+     * @returns {string} A string in the form #RRGGBB
+     */
+    to_hex_code() {
+        const r = format_hex_u8(this.r);
+        const g = format_hex_u8(this.g);
+        const b = format_hex_u8(this.b);
+        return `#${r}${g}${b}`;
+    }
+
+    /**
+     * Parse a color from a hex code like RRGGBB or #RRGGBB. This is useful
+     * when the input came from an HTML color input
+     * @param {string} hex_code The hex code
+     * @returns {Color} The parsed color
+     */
+    static from_hex_code(hex_code) {
+        if (!REGEX_HEX_COLOR.test(hex_code)) {
+            throw new Error("hex_code must be in the form RRGGBB or #RRGGBB");
+        }
+
+        const start = hex_code.charAt(0) === "#" ? 1 : 0;
+        const red_string = hex_code.slice(start, start + 2);
+        const green_string = hex_code.slice(start + 2, start + 4);
+        const blue_string = hex_code.slice(start + 4);
+
+        const red = parseInt(red_string, 16);
+        const green = parseInt(green_string, 16);
+        const blue = parseInt(blue_string, 16);
+
+        return new Color(red, green, blue);
+    }
+}
+// Basic 8 colors for quick prototyping. In practice, these colors are harsh
+// so for final sketches, pick colors more intentionally
+Color.BLACK = Object.freeze(new Color(0, 0, 0));
+Color.RED = Object.freeze(new Color(255, 0, 0));
+Color.GREEN = Object.freeze(new Color(0, 255, 0));
+Color.BLUE = Object.freeze(new Color(0, 0, 255));
+Color.YELLOW = Object.freeze(new Color(255, 255, 0));
+Color.MAGENTA = Object.freeze(new Color(255, 0, 255));
+Color.CYAN = Object.freeze(new Color(0, 255, 255));
+Color.WHITE = Object.freeze(new Color(255, 255, 255));

--- a/sketchlib/Color.test.js
+++ b/sketchlib/Color.test.js
@@ -1,0 +1,37 @@
+import { describe, it, expect } from "vitest";
+import { Color } from "./Color";
+
+describe("Color", () => {
+    it("from_hex_code with invalid hex code throws", () => {
+        expect(() => {
+            return Color.from_hex_code("nope");
+        }).toThrowError("must be in the form");
+    });
+
+    it("to_hex_code formats as CSS color", () => {
+        const color = new Color(3, 45, 255);
+
+        const result = color.to_hex_code();
+
+        const expected = "#032dff";
+        expect(result).toEqual(expected);
+    });
+
+    it("from_hex_code parses CSS color", () => {
+        const hex_code = "#0fab35";
+
+        const result = Color.from_hex_code(hex_code);
+
+        const expected = new Color(0x0f, 0xab, 0x35);
+        expect(result).toEqual(expected);
+    });
+
+    it("from_hex_code parses color without hashtag", () => {
+        const hex_code = "0fab35";
+
+        const result = Color.from_hex_code(hex_code);
+
+        const expected = new Color(0x0f, 0xab, 0x35);
+        expect(result).toEqual(expected);
+    });
+});

--- a/sketchlib/Color.test.js
+++ b/sketchlib/Color.test.js
@@ -1,37 +1,53 @@
 import { describe, it, expect } from "vitest";
-import { Color } from "./Color";
+import { Color } from "./Color.js";
 
 describe("Color", () => {
-    it("from_hex_code with invalid hex code throws", () => {
-        expect(() => {
-            return Color.from_hex_code("nope");
-        }).toThrowError("must be in the form");
-    });
+  it("constructor without alpha sets a=255", () => {
+    const color = new Color(255, 127, 0);
 
-    it("to_hex_code formats as CSS color", () => {
-        const color = new Color(3, 45, 255);
+    const expected = new Color(255, 127, 0, 255);
+    expect(color).toEqual(expected);
+  });
 
-        const result = color.to_hex_code();
+  it("from_hex_code with invalid hex code throws", () => {
+    expect(() => {
+      return Color.from_hex_code("nope");
+    }).toThrowError("must be in the form");
+  });
 
-        const expected = "#032dff";
-        expect(result).toEqual(expected);
-    });
+  it("to_hex_code formats as CSS color", () => {
+    const color = new Color(3, 45, 255);
 
-    it("from_hex_code parses CSS color", () => {
-        const hex_code = "#0fab35";
+    const result = color.to_hex_code();
 
-        const result = Color.from_hex_code(hex_code);
+    const expected = "#032dff";
+    expect(result).toBe(expected);
+  });
 
-        const expected = new Color(0x0f, 0xab, 0x35);
-        expect(result).toEqual(expected);
-    });
+  it("to_hex_code ignores alpha", () => {
+    const color = new Color(1, 2, 3, 127);
 
-    it("from_hex_code parses color without hashtag", () => {
-        const hex_code = "0fab35";
+    const result = color.to_hex_code();
 
-        const result = Color.from_hex_code(hex_code);
+    const expected = "#010203";
+    expect(result).toBe(expected);
+  });
 
-        const expected = new Color(0x0f, 0xab, 0x35);
-        expect(result).toEqual(expected);
-    });
+  it("from_hex_code parses CSS color", () => {
+    const hex_code = "#0fab35";
+
+    const result = Color.from_hex_code(hex_code);
+
+    const expected = new Color(0x0f, 0xab, 0x35);
+    expect(result).toEqual(expected);
+  });
+
+  it("from_hex_code parses color without hashtag", () => {
+    const hex_code = "0fab35";
+
+    const result = Color.from_hex_code(hex_code);
+
+    const expected = new Color(0x0f, 0xab, 0x35);
+    expect(result).toEqual(expected);
+  });
 });

--- a/sketchlib/Style.js
+++ b/sketchlib/Style.js
@@ -7,7 +7,6 @@ import { Color } from "./Color.js";
  * @property {Color} [fill] The fill color
  */
 
-
 /**
  * A Style describes the stroke/fill properties of drawing primitives
  */
@@ -76,4 +75,3 @@ Style.DEFAULT_FILL = Object.freeze(
 Style.DEFAULT_STROKE_FILL = Object.freeze(
   Style.DEFAULT_FILL.with_stroke(Color.WHITE)
 );
-

--- a/sketchlib/Style.js
+++ b/sketchlib/Style.js
@@ -13,17 +13,22 @@ function format_hex_u8(value_u8) {
   return hex_value;
 }
 
+/**
+ * sRGBA color with values in the range [0, 255]
+ */
 export class Color {
   /**
    * Constructor
    * @param {number} r The red component from 0 to 255
    * @param {number} g The green component from 0 to 255
    * @param {number} b The blue component from 0 to 255
+   * @param {number} [a = 255] the alpha component from 0 to 255
    */
-  constructor(r, g, b) {
+  constructor(r, g, b, a) {
     this.r = r;
     this.g = g;
     this.b = b;
+    this.a = a ?? 255;
   }
 
   /**

--- a/sketchlib/Style.js
+++ b/sketchlib/Style.js
@@ -1,80 +1,4 @@
-const REGEX_HEX_COLOR = /^#?[0-9A-Fa-f]{6}$/;
-
-/**
- * Format a u8 as a 2-digit hex number with leading 0s as needed
- * @param {number} value_u8
- */
-function format_hex_u8(value_u8) {
-  const hex_value = value_u8.toString(16);
-  if (hex_value.length === 1) {
-    return `0${hex_value}`;
-  }
-
-  return hex_value;
-}
-
-/**
- * sRGBA color with values in the range [0, 255]
- */
-export class Color {
-  /**
-   * Constructor
-   * @param {number} r The red component from 0 to 255
-   * @param {number} g The green component from 0 to 255
-   * @param {number} b The blue component from 0 to 255
-   * @param {number} [a = 255] the alpha component from 0 to 255
-   */
-  constructor(r, g, b, a) {
-    this.r = r;
-    this.g = g;
-    this.b = b;
-    this.a = a ?? 255;
-  }
-
-  /**
-   * Convert a color to a CSS color code
-   * @returns {string} A string in the form #RRGGBB
-   */
-  to_hex_code() {
-    const r = format_hex_u8(this.r);
-    const g = format_hex_u8(this.g);
-    const b = format_hex_u8(this.b);
-    return `#${r}${g}${b}`;
-  }
-
-  /**
-   * Parse a color from a hex code like RRGGBB or #RRGGBB. This is useful
-   * when the input came from an HTML color input
-   * @param {string} hex_code The hex code
-   * @returns {Color} The parsed color
-   */
-  static from_hex_code(hex_code) {
-    if (!REGEX_HEX_COLOR.test(hex_code)) {
-      throw new Error("hex_code must be in the form RRGGBB or #RRGGBB");
-    }
-
-    const start = hex_code.charAt(0) === "#" ? 1 : 0;
-    const red_string = hex_code.slice(start, start + 2);
-    const green_string = hex_code.slice(start + 2, start + 4);
-    const blue_string = hex_code.slice(start + 4);
-
-    const red = parseInt(red_string, 16);
-    const green = parseInt(green_string, 16);
-    const blue = parseInt(blue_string, 16);
-
-    return new Color(red, green, blue);
-  }
-}
-// Basic 8 colors for quick prototyping. In practice, these colors are harsh
-// so for final sketches, pick colors more intentionally
-Color.BLACK = Object.freeze(new Color(0, 0, 0));
-Color.RED = Object.freeze(new Color(255, 0, 0));
-Color.GREEN = Object.freeze(new Color(0, 255, 0));
-Color.BLUE = Object.freeze(new Color(0, 0, 255));
-Color.YELLOW = Object.freeze(new Color(255, 255, 0));
-Color.MAGENTA = Object.freeze(new Color(255, 0, 255));
-Color.CYAN = Object.freeze(new Color(0, 255, 255));
-Color.WHITE = Object.freeze(new Color(255, 255, 255));
+import { Color } from "./Color.js";
 
 /**
  * @typedef {Object} StyleDescriptor
@@ -83,6 +7,10 @@ Color.WHITE = Object.freeze(new Color(255, 255, 255));
  * @property {Color} [fill] The fill color
  */
 
+
+/**
+ * A Style describes the stroke/fill properties of drawing primitives
+ */
 export class Style {
   /**
    * Constructor
@@ -148,3 +76,4 @@ Style.DEFAULT_FILL = Object.freeze(
 Style.DEFAULT_STROKE_FILL = Object.freeze(
   Style.DEFAULT_FILL.with_stroke(Color.WHITE)
 );
+

--- a/sketchlib/Style.test.js
+++ b/sketchlib/Style.test.js
@@ -1,40 +1,7 @@
 import { describe, it, expect } from "vitest";
-import { Color, Style } from "./Style";
+import { Style } from "./Style";
+import { Color } from "./Color";
 
-describe("Color", () => {
-  it("from_hex_code with invalid hex code throws", () => {
-    expect(() => {
-      return Color.from_hex_code("nope");
-    }).toThrowError("must be in the form");
-  });
-
-  it("to_hex_code formats as CSS color", () => {
-    const color = new Color(3, 45, 255);
-
-    const result = color.to_hex_code();
-
-    const expected = "#032dff";
-    expect(result).toEqual(expected);
-  });
-
-  it("from_hex_code parses CSS color", () => {
-    const hex_code = "#0fab35";
-
-    const result = Color.from_hex_code(hex_code);
-
-    const expected = new Color(0x0f, 0xab, 0x35);
-    expect(result).toEqual(expected);
-  });
-
-  it("from_hex_code parses color without hashtag", () => {
-    const hex_code = "0fab35";
-
-    const result = Color.from_hex_code(hex_code);
-
-    const expected = new Color(0x0f, 0xab, 0x35);
-    expect(result).toEqual(expected);
-  });
-});
 
 describe("Style", () => {
   it("constructor with empty object returns transparent style", () => {

--- a/sketchlib/Tween.js
+++ b/sketchlib/Tween.js
@@ -1,16 +1,6 @@
 import { Point } from "../pga2d/objects.js";
 import { clamp } from "./clamp.js";
-
-/**
- * Lerp for numbers
- * @param {number} a The first number
- * @param {number} b The second number
- * @param {number} t The time value
- * @returns {number} The blend of a and b proportional to t
- */
-function lerp(a, b, t) {
-  return (1 - t) * a + t * b;
-}
+import { lerp } from "./lerp.js";
 
 /**
  * An object to manage inbetweening for animation

--- a/sketchlib/lerp.js
+++ b/sketchlib/lerp.js
@@ -1,0 +1,10 @@
+/**
+ * Lerp for numbers
+ * @param {number} a The first number
+ * @param {number} b The second number
+ * @param {number} t The time value
+ * @returns {number} The blend of a and b proportional to t
+ */
+export function lerp(a, b, t) {
+    return (1 - t) * a + t * b;
+}

--- a/sketchlib/lerp.test.js
+++ b/sketchlib/lerp.test.js
@@ -1,0 +1,63 @@
+import { describe, it, expect } from "vitest";
+import { lerp } from "./lerp";
+
+describe("lerp", () => {
+  it("with t < 0 extrapolates", () => {
+    let a = 1;
+    let b = 5;
+
+    let result = lerp(a, b, -1);
+
+    // (1 - -1) * 1 - 1 * 5 = 2 - 5 = -3
+    const expected = -3;
+    expect(result).toBe(expected);
+  });
+
+  it("with t = 0 returns a", () => {
+    let a = 1;
+    let b = 5;
+
+    let result = lerp(a, b, 0);
+
+    expect(result).toBe(a);
+  });
+
+  it("with t in between interpolates", () => {
+    let a = 1;
+    let b = 5;
+
+    let result = lerp(a, b, 0.25);
+
+    // 3/4 * 1 + 1/4 * 5 = (3 + 5)/4 = 8/4 = 2
+    const expected = 2;
+    expect(result).toBe(expected);
+  });
+
+  it("with t = 1 returns b", () => {
+    let a = 1;
+    let b = 5;
+
+    let result = lerp(a, b, 1);
+
+    expect(result).toBe(b);
+  });
+
+  it("with t > 1 extrapolates", () => {
+    let a = 1;
+    let b = 5;
+
+    let result = lerp(a, b, 2);
+
+    // (1 - 2) * 1 + 2 * 5 = -1 + 10 = 9
+    const expected = 9;
+    expect(result).toBe(expected);
+  });
+
+  it("with a = b returns a", () => {
+    let a = 1;
+
+    let result = lerp(a, a, 0.75);
+
+    expect(result).toBe(a);
+  });
+});


### PR DESCRIPTION
Recently I've learned about the [Oklch color space](https://bottosson.github.io/posts/oklab/). I've already explored this a bit in `webgpu-sketchbook`, but it's actually more useful to me here in `p5-sketchbook`

So far I'm trying it out in one of the labs - I colored the springs in Double Spring.

![image](https://github.com/user-attachments/assets/2a6079ae-939c-4338-a2f2-5a0f29fd3ff5)

I'm leaving `Oklch` in lab for a bit to see how I like the interface.
