### PR TITLE
Add more music-related types

### DIFF
--- a/lab/lablib/Rational.js
+++ b/lab/lablib/Rational.js
@@ -81,6 +81,18 @@ export class Rational {
     // The constructor puts the fraction in lowest terms
     return new Rational(numerator, denominator);
   }
+
+  /**
+   * Multiply two rational numbers
+   * @param {Rational} other Another rational number
+   * @returns {Rational} The product
+   */
+  mul(other) {
+    const { numerator: a, denominator: b } = this;
+    const { numerator: c, denominator: d } = other;
+
+    return new Rational(a * c, b * c);
+  }
 }
 
 Rational.ZERO = Object.freeze(new Rational(0, 1));

--- a/lab/lablib/Rational.js
+++ b/lab/lablib/Rational.js
@@ -19,6 +19,19 @@ function gcd(a, b) {
 }
 
 /**
+ * like Math.sign, but sign_nonzero(0) = 1, not 0.
+ * @param {number} x Input number
+ * @returns {number} 1 if x is >= 0, -1 otherwise
+ */
+function sign_nonzero(x) {
+  if (x < 0) {
+    return -1;
+  }
+
+  return 1;
+}
+
+/**
  * Rational number a / b stored in lowest terms. For negative fractions,
  * this is normalized so the negative sign is in the numerator
  */
@@ -35,7 +48,7 @@ export class Rational {
 
     const a = Math.abs(numerator);
     const b = Math.abs(denominator);
-    const sign = Math.sign(numerator) * Math.sign(denominator);
+    const sign = sign_nonzero(numerator) * sign_nonzero(denominator);
 
     const d = gcd(a, b);
     this.numerator = sign * (a / d);
@@ -91,7 +104,7 @@ export class Rational {
     const { numerator: a, denominator: b } = this;
     const { numerator: c, denominator: d } = other;
 
-    return new Rational(a * c, b * c);
+    return new Rational(a * c, b * d);
   }
 }
 

--- a/lab/lablib/Rational.test.js
+++ b/lab/lablib/Rational.test.js
@@ -15,6 +15,13 @@ describe("Rational", () => {
       const expected = new Rational(1, 3);
       expect(rational).toEqual(expected);
     });
+
+    it("infinity is stored as 1/0", () => {
+      const inf = Rational.INF;
+
+      expect(inf.numerator).toBe(1);
+      expect(inf.denominator).toBe(0);
+    });
   });
 
   describe("add", () => {
@@ -75,6 +82,33 @@ describe("Rational", () => {
 
       const expected = 3;
       expect(result).toBe(expected);
+    });
+  });
+
+  describe("mul", () => {
+    it("computes product in lowest terms", () => {
+      const a = new Rational(-3, 4);
+      const b = new Rational(1, 3);
+
+      const result = a.mul(b);
+
+      // -3/4 * 1/3 = -3/12 = -1/4
+      const expected = new Rational(-1, 4);
+      expect(result).toEqual(expected);
+    });
+
+    it("0 times infinity throws error", () => {
+      const a = Rational.INF;
+      const b = Rational.ZERO;
+      expect(() => {
+        return a.mul(b);
+      }).toThrowError("cannot divide 0 by 0");
+    });
+
+    it("inf times inf returns inf", () => {
+      const result = Rational.INF.mul(Rational.INF);
+
+      expect(result).toEqual(Rational.INF);
     });
   });
 });

--- a/lab/lablib/SoundManager.js
+++ b/lab/lablib/SoundManager.js
@@ -102,13 +102,6 @@ export class SoundManager {
     pedal.loopStart = "0:0";
     pedal.loopEnd = "0:2";
 
-    // Not sure what you call this but it sounds kinda neat
-    const NOTES = ["C", "E", "F", "G", "G#", "B"];
-    // Notes at different octaves
-    const NOTES3 = NOTES.map((x) => `${x}3`);
-    const NOTES4 = NOTES.map((x) => `${x}4`);
-    const NOTES5 = NOTES.map((x) => `${x}5`);
-
     const SCALE = [C, E, F, G, GS, B];
     const SCALE3 = scale_to_pitch(SCALE, 3);
     const SCALE4 = scale_to_pitch(SCALE, 4);
@@ -161,26 +154,32 @@ export class SoundManager {
     );
 
     // Three scales initially the same, but with different lengths
-    const phase_a = new this.tone.Sequence(
-      (time, note) => {
-        this.synths.poly.triggerAttackRelease(NOTES3[note], "8n", time);
-      },
-      [0, 1, 2, 3, 2, 1],
-      "8n"
+    const phase_a_score = Cycle.parse(
+      new Rational(6, 8),
+      [0, 1, 2, 3, 2, 1]
+    ).map_pitch(SCALE3);
+    const phase_a = compile_sequence(
+      this.tone,
+      this.synths.poly,
+      phase_a_score
     );
-    const phase_b = new this.tone.Sequence(
-      (time, note) => {
-        this.synths.poly.triggerAttackRelease(NOTES4[note], "8n", time);
-      },
-      [0, 1, 2, 3, 4, 3, 2, 1],
-      "8n"
+    const phase_b_score = Cycle.parse(
+      new Rational(1, 1),
+      [0, 1, 2, 3, 4, 3, 2, 1]
+    ).map_pitch(SCALE3);
+    const phase_b = compile_sequence(
+      this.tone,
+      this.synths.poly,
+      phase_b_score
     );
-    const phase_c = new this.tone.Sequence(
-      (time, note) => {
-        this.synths.poly.triggerAttackRelease(NOTES5[note], "8n", time);
-      },
-      [0, 1, 2, 3, 4, 5, 4, 3, 2, 1],
-      "8n"
+    const phase_c_score = Cycle.parse(
+      new Rational(10, 8),
+      [0, 1, 2, 3, 4, 5, 4, 3, 2, 1]
+    ).map_pitch(SCALE3);
+    const phase_c = compile_sequence(
+      this.tone,
+      this.synths.poly,
+      phase_c_score
     );
 
     patterns.pedal = pedal;

--- a/lab/lablib/SoundManager.js
+++ b/lab/lablib/SoundManager.js
@@ -150,35 +150,15 @@ export class SoundManager {
     );
 
     const cycle_b_score = Cycle.parse(cycle_length, [
-      0,
-      4,
-      [1, 2],
-      3,
-      [0, REST, 3],
+      [0, 3],
+      [5, REST],
+      [0, 4, 2, 4],
     ]).map_pitch(SCALE5);
     const cycle_b = compile_sequence(
       this.tone,
       this.synths.poly,
       cycle_b_score
     );
-
-    /*
-    const cycle_a = new this.tone.Sequence(
-      (time, note) => {
-        this.synths.poly.triggerAttackRelease(NOTES5[note], "8n", time);
-      },
-      [0, undefined, 1, 2, undefined, 4],
-      "8n"
-    );
-
-    const cycle_b = new this.tone.Sequence(
-      (time, note) => {
-        this.synths.poly.triggerAttackRelease(NOTES5[note], "8n", time);
-      },
-      [0, 4, [1, 2], 3, [0, undefined, 3]],
-      "8n"
-    );
-    */
 
     // Three scales initially the same, but with different lengths
     const phase_a = new this.tone.Sequence(

--- a/lab/lablib/music/Score.js
+++ b/lab/lablib/music/Score.js
@@ -1,4 +1,5 @@
 import { Rational } from "../Rational.js";
+import { REST } from "./pitches.js";
 
 export class Rest {
   /**
@@ -154,6 +155,37 @@ export class Cycle {
   map_pitch(convert_pitch) {
     const converted = this.children.map((x) => x.map_pitch(convert_pitch));
     return new Cycle(this.duration, ...converted);
+  }
+
+  /**
+   * Parse a cycle from an array
+   * @example
+   * const cycle = Cycle.parse(N1, [C4, D4, [E4, F4], G4]);
+   * @template P
+   * @param {Rational} cycle_length Length of one cycle
+   * @param  {(P | P[])[]} notes List of pitch values or arrays thereof. Arrays are interpreted as nested cycles
+   * @returns {Cycle<P>} The comuted cyles
+   */
+  static parse(cycle_length, notes) {
+    const children = [];
+    const subdivision = new Rational(1, notes.length);
+    const beat_length = cycle_length.mul(subdivision);
+    for (const note of notes) {
+      let child;
+      if (note === REST) {
+        child = new Rest(subdivision);
+      } else if (Array.isArray(note)) {
+        // Interpret arrays
+        child = Cycle.parse(beat_length, note);
+      } else {
+        // Numbers are interpreted as notes as long as the cycle length
+        child = new Note(note, subdivision);
+      }
+
+      children.push(child);
+    }
+
+    return new Cycle(cycle_length, ...children);
   }
 }
 

--- a/lab/lablib/music/Score.js
+++ b/lab/lablib/music/Score.js
@@ -8,6 +8,14 @@ export class Rest {
   constructor(duration) {
     this.duration = duration;
   }
+
+  /**
+   * A rest does not have any pitches, so map_pitch is the identity
+   * @return {Rest} A new alternation with pitches of the destination type
+   */
+  map_pitch() {
+    return this;
+  }
 }
 
 /**
@@ -24,6 +32,16 @@ export class Note {
     this.pitch = pitch;
     this.duration = duration;
   }
+
+  /**
+   * Map the pitch type to a new type
+   * @template Q The new pitch type
+   * @param {function(P): Q} convert_pitch Function to convert pitch types
+   * @return {Note<Q>} A new alternation with pitches of the destination type
+   */
+  map_pitch(convert_pitch) {
+    return new Note(convert_pitch(this.pitch), this.duration);
+  }
 }
 
 /**
@@ -33,14 +51,14 @@ export class Note {
 export class Melody {
   /**
    * Constructor
-   * @param {(Rest | Note<P>)[]} values Values to put in sequence
+   * @param {...Music<P>} children Inner musical material
    */
-  constructor(...values) {
-    this.values = values;
+  constructor(...children) {
+    this.children = children;
   }
 
   get duration() {
-    return this.values.reduce((accum, x) => {
+    return this.children.reduce((accum, x) => {
       return accum.add(x.duration);
     }, Rational.ZERO);
   }
@@ -52,15 +70,8 @@ export class Melody {
    * @return {Melody<Q>} A new melody with pitches of the destination type
    */
   map_pitch(convert_pitch) {
-    const new_values = this.values.map((x) => {
-      if (x instanceof Note) {
-        return new Note(convert_pitch(x.pitch), x.duration);
-      }
-
-      return x;
-    });
-
-    return new Melody(...new_values);
+    const converted = this.children.map((x) => x.map_pitch(convert_pitch));
+    return new Melody(...converted);
   }
 
   /**
@@ -70,14 +81,167 @@ export class Melody {
    * @returns {Melody<P>} The parsed melody
    */
   static parse(...tuples) {
-    const values = [];
+    const children = [];
     for (const tuple of tuples) {
       const [pitch, duration] = tuple;
       const note =
         pitch === undefined ? new Rest(duration) : new Note(pitch, duration);
-      values.push(note);
+      children.push(note);
     }
 
-    return new Melody(...values);
+    return new Melody(...children);
+  }
+}
+
+/**
+ * Musical material played simultaneously. Note that this will only sound
+ * correctly when played with a polyphonic instrument.
+ * @template P
+ */
+export class Harmony {
+  /**
+   * Constructor
+   * @param  {...Music<P>} children
+   */
+  constructor(...children) {
+    this.children = children;
+  }
+
+  /**
+   * Map the pitch type to a new type
+   * @template Q The new pitch type
+   * @param {function(P): Q} convert_pitch
+   * @return {Harmony<Q>} A new harmony with pitches of the destination type
+   */
+  map_pitch(convert_pitch) {
+    const converted = this.children.map((x) => x.map_pitch(convert_pitch));
+    return new Harmony(...converted);
+  }
+
+  /**
+   * Compute the duration as the max of the children's durations
+   * @type {number}
+   */
+  get duration() {
+    return this.children.reduce((accum, x) => Math.max(accum, x.duration), 0);
+  }
+}
+
+/**
+ * A fixed length loop of time that is evenly divided amongst its children.
+ * This is based on cycles from Tidal Cycles.
+ * @see {@link https://tidalcycles.org/docs/reference/cycles|Tidal Cycles Reference}
+ * @template P
+ */
+export class Cycle {
+  /**
+   * Constructor
+   * @param {Rational} duration The duration of 1 cycle
+   * @param  {...Music<P>} children Children music objects. Each one will receive the same fraction of a cycle
+   */
+  constructor(duration, ...children) {
+    this.duration = duration;
+    this.children = children;
+    this.subdivision = new Rational(1, children.length);
+  }
+
+  /**
+   * Map the pitch type to a new type
+   * @template Q The new pitch type
+   * @param {function(P): Q} convert_pitch
+   * @return {Cycle<Q>} A new cycle with pitches of the destination type
+   */
+  map_pitch(convert_pitch) {
+    const converted = this.children.map((x) => x.map_pitch(convert_pitch));
+    return new Cycle(this.duration, ...converted);
+  }
+}
+
+/**
+ * A collection of musical material. Each time the parent container loops,
+ * The next option from the list is selected (cycling around at the end)
+ *
+ * This is inspired by the alternation notation in Tidal Cycles
+ * @see {@link https://tidalcycles.org/docs/reference/mini_notation|Tidal Cycles Reference}
+ * @template P
+ */
+export class Alternation {
+  /**
+   * constructor
+   * @param  {...Music<P>} children Musical material treated as options to select from
+   */
+  constructor(...children) {
+    this.children = children;
+  }
+
+  /**
+   * The duration of an alternation is a bit ambiguous, I choose to use the
+   * maximum length of the children, similar to Harmony
+   * @type {number}
+   */
+  get duration() {
+    return this.children.reduce((accum, x) => Math.max(accum, x.duration), 0);
+  }
+
+  /**
+   * Map the pitch type to a new type
+   * @template Q The new pitch type
+   * @param {function(P): Q} convert_pitch Function to convert pitch types
+   * @return {Alternation<Q>} A new alternation with pitches of the destination type
+   */
+  map_pitch(convert_pitch) {
+    const converted = this.children.map((x) => x.map_pitch(convert_pitch));
+    return new Harmony(...converted);
+  }
+}
+
+/**
+ * Fixed-length clip of music. If it is longer than its contents,
+ * the contents are played on loop for the given duration. If it is shorter
+ * than its contents, only part of the music will be played
+ * @template P
+ */
+export class Clip {
+  /**
+   * Constructor
+   * @param {Rational} duration The length of the clip (this can be different)
+   * @param {Music<P>} child The musical content of the clip
+   */
+  constructor(duration, child) {
+    this.duration = duration;
+    this.child = child;
+  }
+
+  /**
+   * Map the pitch type to a new type
+   * @template Q The new pitch type
+   * @param {function(P): Q} convert_pitch Function to convert pitch types
+   * @return {Clip<Q>} A new clip with pitches of the destination type
+   */
+  map_pitch(convert_pitch) {
+    return new Clip(this.duration, this.child.map_pitch(convert_pitch));
+  }
+}
+
+/**
+ * @template P
+ * @typedef {Rest | Note<P> | Melody<P> | Harmony<P> | Cycle<P> | Alternation<P> | Clip<P>} Music<P>
+ */
+
+/**
+ * @typedef {number} Instrument
+ */
+
+/**
+ * A score is a container for music with instruments labeled.
+ * @template P
+ */
+export class Score {
+  /**
+   * Constructor
+   * @param  {...[Instrument, Music<P>]} parts
+   */
+  constructor(...parts) {
+    this.parts = parts;
   }
 }

--- a/lab/lablib/tone_helpers/compile_music.js
+++ b/lab/lablib/tone_helpers/compile_music.js
@@ -1,4 +1,4 @@
-import { Melody, Note, Rest } from "../music/Score.js";
+import { Cycle, Melody, Note, Rest } from "../music/Score.js";
 import { Rational } from "../Rational.js";
 import { to_tone_time } from "./measure_notation.js";
 import { to_tone_pitch } from "./to_tone_pitch.js";
@@ -51,4 +51,28 @@ export function compile_part(tone, instrument, midi_melody) {
     const [pitch, duration] = note;
     instrument.triggerAttackRelease(pitch, duration, time);
   }, events);
+}
+
+export function compile_sequence_pattern(midi_cycle) {
+  return [];
+}
+
+/**
+ * @param {import("tone")} tone the Tone.js library
+ * @param {import("tone").Synth} instrument the instrument to play
+ * @param {Cycle<number>} midi_cycle Cycle of MIDI notes
+ * @returns {import("tone").Sequence} The computed part
+ */
+export function compile_sequence(tone, instrument, midi_cycle) {
+  const pattern = compile_sequence_pattern(midi_cycle);
+  const beat_duration = midi_cycle.duration.mul(midi_cycle.subdivision);
+  const tone_interval = to_tone_time(beat_duration);
+  return new tone.Sequence(
+    (time, note) => {
+      const [pitch, duration] = note;
+      instrument.triggerAttackRelease(pitch, duration, time);
+    },
+    pattern,
+    tone_interval
+  );
 }

--- a/lab/lablib/tone_helpers/compile_music.js
+++ b/lab/lablib/tone_helpers/compile_music.js
@@ -1,4 +1,4 @@
-import { Melody, Rest } from "../music/Score.js";
+import { Melody, Note, Rest } from "../music/Score.js";
 import { Rational } from "../Rational.js";
 import { to_tone_time } from "./measure_notation.js";
 import { to_tone_pitch } from "./to_tone_pitch.js";
@@ -13,23 +13,28 @@ import { to_tone_pitch } from "./to_tone_pitch.js";
 export function compile_part_events(midi_melody) {
   const events = [];
   let offset = Rational.ZERO;
-  for (const note of midi_melody.values) {
+  for (const note of midi_melody.children) {
     if (note instanceof Rest) {
       offset = offset.add(note.duration);
       continue;
     }
 
-    const start = to_tone_time(offset);
-    const pitch = to_tone_pitch(note.pitch);
-    const dur = to_tone_time(note.duration);
+    if (note instanceof Note) {
+      const start = to_tone_time(offset);
+      const pitch = to_tone_pitch(note.pitch);
+      const dur = to_tone_time(note.duration);
 
-    /**
-     * @type {[string, [string, string]]}
-     */
-    const event = [start, [pitch, dur]];
+      /**
+       * @type {[string, [string, string]]}
+       */
+      const event = [start, [pitch, dur]];
 
-    events.push(event);
-    offset = offset.add(note.duration);
+      events.push(event);
+      offset = offset.add(note.duration);
+      continue;
+    }
+
+    throw new Error("other musical types not implemented");
   }
   return events;
 }

--- a/lab/lablib/tone_helpers/compile_music.test.js
+++ b/lab/lablib/tone_helpers/compile_music.test.js
@@ -1,11 +1,11 @@
 import { describe, it, expect } from "vitest";
-import { Melody, Note, Rest } from "../music/Score";
-import { compile_part_events } from "./compile_music";
+import { Cycle, Melody, Note, Rest } from "../music/Score";
+import { compile_part_events, compile_sequence_pattern } from "./compile_music";
 import { N1, N2, N4 } from "../music/durations";
-import { C4, E4, G4 } from "../music/pitches";
+import { C4, E4, G4, REST } from "../music/pitches";
 
 describe("compile_part_events", () => {
-  it("with melody returns empty array", () => {
+  it("with empty melody returns empty array", () => {
     const empty = new Melody();
 
     const result = compile_part_events(empty);
@@ -45,6 +45,53 @@ describe("compile_part_events", () => {
       // rest is skipped
       ["0:3", ["E4", "0:1"]],
       ["1:0", ["G4", "1:0"]],
+    ];
+    expect(result).toEqual(expected);
+  });
+});
+
+describe("compile_sequence_pattern", () => {
+  it("with empty sequence returns empty array", () => {
+    const empty = new Cycle(N1);
+
+    const result = compile_sequence_pattern(empty);
+
+    expect(result).toEqual([]);
+  });
+
+  it("with notes and rests returns flat array", () => {
+    const cycle = new Cycle(
+      N1,
+      new Note(C4, N2),
+      new Rest(N4),
+      new Note(E4, N4),
+      new Note(G4, N4)
+    );
+
+    const result = compile_sequence_pattern(cycle);
+
+    const expected = ["C4", REST, "E4", "G4"];
+    expect(result).toEqual(expected);
+  });
+
+  it("with nested cycles returns nested array", () => {
+    const note = new Note(C4, N4);
+    const rest = new Rest(N4);
+    const cycle = new Cycle(
+      N1,
+      note,
+      new Cycle(N1, note, note),
+      new Cycle(N1, note, new Cycle(N1, rest, rest, note)),
+      new Cycle(N1, note, rest, note)
+    );
+
+    const result = compile_sequence_pattern(cycle);
+
+    const expected = [
+      "C4",
+      ["C4", "C4"],
+      ["C4", [REST, REST, "C4"]],
+      ["C4", REST, "C4"],
     ];
     expect(result).toEqual(expected);
   });


### PR DESCRIPTION
This PR:

- Adds more types like `Harmony, Melody, Cycle`
- Compiles `Cycle` to a `Tone.Sequence`. It's pretty basic so far, I'm not handling the individual note durations (which matters for nested cycles)