### PR TITLE
Regroup

### DIFF
--- a/Anabaena/Anabaena.js
+++ b/Anabaena/Anabaena.js
@@ -8,12 +8,12 @@ import { LSystem } from "./LSystem.js";
 import { sec_to_frames, Tween } from "../sketchlib/Tween.js";
 import { AnimationChain, Joint } from "../sketchlib/AnimationChain.js";
 import {
-  GroupPrimitive,
   LinePrimitive,
   VectorPrimitive,
 } from "../sketchlib/rendering/primitives.js";
 import { Style } from "../sketchlib/Style.js";
 import { Color } from "../sketchlib/Color.js";
+import { GroupPrimitive } from "../sketchlib/rendering/GroupPrimitive.js";
 
 const INITIAL_POSITION = Point.point(WIDTH / 2, HEIGHT - 50);
 const MIN_BEND_ANGLE = (7 * Math.PI) / 8;
@@ -223,12 +223,12 @@ class AnabaenaCatenula {
     }
 
     const primitives = [
-      new GroupPrimitive(l_cells, STYLE_CELL_L),
-      new GroupPrimitive(s_cells, STYLE_CELL_S),
+      new GroupPrimitive(l_cells, { style: STYLE_CELL_L }),
+      new GroupPrimitive(s_cells, { style: STYLE_CELL_S }),
     ];
 
     if (show_arrows) {
-      primitives.push(new GroupPrimitive(arrows, STYLE_ARROW));
+      primitives.push(new GroupPrimitive(arrows, { style: STYLE_ARROW }));
     }
 
     return new GroupPrimitive(primitives);

--- a/Anabaena/Anabaena.js
+++ b/Anabaena/Anabaena.js
@@ -1,7 +1,7 @@
 import { WIDTH, HEIGHT } from "../sketchlib/dimensions.js";
 import { fix_mouse_coords } from "../sketchlib/fix_mouse_coords.js";
 
-import { draw_primitive } from "../sketchlib/draw_primitive.js";
+import { draw_primitive } from "../sketchlib/p5_helpers/draw_primitive.js";
 import { Point } from "../pga2d/objects.js";
 import { prevent_mobile_scroll } from "../sketchlib/prevent_mobile_scroll.js";
 import { LSystem } from "./LSystem.js";

--- a/Anabaena/Anabaena.js
+++ b/Anabaena/Anabaena.js
@@ -11,7 +11,7 @@ import {
   GroupPrimitive,
   LinePrimitive,
   VectorPrimitive,
-} from "../sketchlib/primitives.js";
+} from "../sketchlib/rendering/primitives.js";
 import { Style } from "../sketchlib/Style.js";
 import { Color } from "../sketchlib/Color.js";
 

--- a/Coral/Maze/Maze.js
+++ b/Coral/Maze/Maze.js
@@ -1,4 +1,3 @@
-import { GroupPrimitive } from "../../sketchlib/rendering/primitives.js";
 import { draw_primitive } from "../../sketchlib/p5_helpers/draw_primitive.js";
 import { generate_maze } from "../../sketchlib/RandomDFSMaze.js";
 import { CoralTile } from "../CoralTile.js";
@@ -16,6 +15,7 @@ import {
   SPLINE_STYLE,
 } from "../styles.js";
 import { Grid } from "../../sketchlib/Grid.js";
+import { GroupPrimitive } from "../../sketchlib/rendering/GroupPrimitive.js";
 
 const WIDTH = 500;
 const HEIGHT = 700;
@@ -34,7 +34,7 @@ QUADS.fill((index) => {
 const QUAD_PRIMS = QUADS.map_array((_, quad) => {
   return render_quad(quad);
 }).flat();
-const QUAD_GROUP = new GroupPrimitive(QUAD_PRIMS, GRID_STYLE);
+const QUAD_GROUP = new GroupPrimitive(QUAD_PRIMS, { style: GRID_STYLE });
 
 function make_default_tiles(grid) {
   return grid.map((index, cell) => {
@@ -53,7 +53,7 @@ function make_tiles_from_tileset(grid, coral_tiles) {
 function render_splines(tile_grid) {
   const splines = find_splines(tile_grid);
   const spline_prims = splines.flatMap((x) => x.to_bezier_world());
-  return new GroupPrimitive(spline_prims, SPLINE_STYLE);
+  return new GroupPrimitive(spline_prims, { style: SPLINE_STYLE });
 }
 
 function render_connections(tile_grid) {
@@ -62,7 +62,7 @@ function render_connections(tile_grid) {
       return render_tile_connections(tile);
     })
     .flat();
-  return new GroupPrimitive(connection_prims, CONNECTION_STYLE);
+  return new GroupPrimitive(connection_prims, { style: CONNECTION_STYLE });
 }
 
 function render_walls(tile_grid) {
@@ -71,7 +71,7 @@ function render_walls(tile_grid) {
       return render_tile_walls(tile);
     })
     .flat();
-  return new GroupPrimitive(wall_prims, WALL_STYLE);
+  return new GroupPrimitive(wall_prims, { style: WALL_STYLE });
 }
 
 function render_geometry(tile_grid) {
@@ -84,8 +84,9 @@ function render_geometry(tile_grid) {
 function slurp_json(file) {
   const reader = new FileReader();
   const promise = new Promise((resolve, reject) => {
-    reader.addEventListener("load", (e) => {
+    reader.addEventListener("load", (/** @type {ProgressEvent} */ e) => {
       try {
+        //@ts-ignore
         const tileset = JSON.parse(e.target.result);
         resolve(tileset);
       } catch (err) {
@@ -152,6 +153,7 @@ export const sketch = (p) => {
     document.getElementById("import").addEventListener("input", async (e) => {
       clear_errors();
       try {
+        //@ts-ignore
         tileset = await import_tileset(e.target.files);
         update_geometry();
       } catch (err) {

--- a/Coral/Maze/Maze.js
+++ b/Coral/Maze/Maze.js
@@ -1,4 +1,4 @@
-import { GroupPrimitive } from "../../sketchlib/primitives.js";
+import { GroupPrimitive } from "../../sketchlib/rendering/primitives.js";
 import { draw_primitive } from "../../sketchlib/draw_primitive.js";
 import { generate_maze } from "../../sketchlib/RandomDFSMaze.js";
 import { CoralTile } from "../CoralTile.js";

--- a/Coral/Maze/Maze.js
+++ b/Coral/Maze/Maze.js
@@ -1,5 +1,5 @@
 import { GroupPrimitive } from "../../sketchlib/rendering/primitives.js";
-import { draw_primitive } from "../../sketchlib/draw_primitive.js";
+import { draw_primitive } from "../../sketchlib/p5_helpers/draw_primitive.js";
 import { generate_maze } from "../../sketchlib/RandomDFSMaze.js";
 import { CoralTile } from "../CoralTile.js";
 import { Rect } from "../Rect.js";

--- a/Coral/Spline.js
+++ b/Coral/Spline.js
@@ -1,4 +1,4 @@
-import { BezierPrimitive } from "../sketchlib/primitives.js";
+import { BezierPrimitive } from "../sketchlib/rendering/primitives.js";
 
 export class Spline {
   constructor(control_points) {

--- a/Coral/TileEditor/TileEditor.js
+++ b/Coral/TileEditor/TileEditor.js
@@ -15,7 +15,7 @@ import {
   GroupPrimitive,
   LinePrimitive,
   PointPrimitive,
-} from "../../sketchlib/primitives.js";
+} from "../../sketchlib/rendering/primitives.js";
 import { draw_primitive } from "../../sketchlib/draw_primitive.js";
 import {
   GRID_STYLE,

--- a/Coral/TileEditor/TileEditor.js
+++ b/Coral/TileEditor/TileEditor.js
@@ -16,7 +16,7 @@ import {
   LinePrimitive,
   PointPrimitive,
 } from "../../sketchlib/rendering/primitives.js";
-import { draw_primitive } from "../../sketchlib/draw_primitive.js";
+import { draw_primitive } from "../../sketchlib/p5_helpers/draw_primitive.js";
 import {
   GRID_STYLE,
   WALL_STYLE,

--- a/Coral/TileEditor/TileEditor.js
+++ b/Coral/TileEditor/TileEditor.js
@@ -12,7 +12,6 @@ import {
 } from "../rendering.js";
 import {
   CirclePrimitive,
-  GroupPrimitive,
   LinePrimitive,
   PointPrimitive,
 } from "../../sketchlib/rendering/primitives.js";
@@ -25,6 +24,7 @@ import {
 } from "../styles.js";
 import { Color } from "../../sketchlib/Color.js";
 import { Direction } from "../../sketchlib/Direction.js";
+import { GroupPrimitive } from "../../sketchlib/rendering/GroupPrimitive.js";
 
 const WIDTH = 500;
 const HEIGHT = 700;
@@ -91,9 +91,13 @@ function render_control_points(tiles) {
   }
 
   // It's important to draw the points over the line
-  const tangent_line_group = new GroupPrimitive(tangent_lines, TANGENT_STYLE);
-  const vertex_group = new GroupPrimitive(vertices, VERTEX_STYLE);
-  const tangent_group = new GroupPrimitive(tangent_tips, TANGENT_TIP_STYLE);
+  const tangent_line_group = new GroupPrimitive(tangent_lines, {
+    style: TANGENT_STYLE,
+  });
+  const vertex_group = new GroupPrimitive(vertices, { style: VERTEX_STYLE });
+  const tangent_group = new GroupPrimitive(tangent_tips, {
+    style: TANGENT_TIP_STYLE,
+  });
   return new GroupPrimitive([tangent_line_group, vertex_group, tangent_group]);
 }
 
@@ -103,23 +107,25 @@ function highlight_selection(selected_object) {
     selected_object.position_world,
     HIGHLIGHT_RADIUS
   );
-  return new GroupPrimitive([circle], HIGHLIGHT_STYLE);
+  return new GroupPrimitive([circle], { style: HIGHLIGHT_STYLE });
 }
 
 const QUAD_PRIMS = SMALL_QUADS.map_array((_, quad) => {
   return render_quad(quad);
 }).flat();
-const QUADS = new GroupPrimitive(QUAD_PRIMS, GRID_STYLE);
+const QUADS = new GroupPrimitive(QUAD_PRIMS, { style: GRID_STYLE });
 
 const CONNECTION_PRIMS = TILES.map_array((_, tile) => {
   return render_tile_connections(tile);
 }).flat();
-const CONNECTIONS = new GroupPrimitive(CONNECTION_PRIMS, CONNECTION_STYLE);
+const CONNECTIONS = new GroupPrimitive(CONNECTION_PRIMS, {
+  style: CONNECTION_STYLE,
+});
 
 const WALL_PRIMS = TILES.map_array((_, tile) => {
   return render_tile_walls(tile);
 }).flat();
-const WALLS = new GroupPrimitive(WALL_PRIMS, WALL_STYLE);
+const WALLS = new GroupPrimitive(WALL_PRIMS, { style: WALL_STYLE });
 
 const STATIC_GEOMETRY = new GroupPrimitive([QUADS, CONNECTIONS, WALLS]);
 
@@ -151,7 +157,7 @@ function you_wouldnt_download_a_json(json, fname) {
 
 function update_spline_primitives() {
   const spline_prims = SPLINES.flatMap((x) => x.to_bezier_world());
-  return new GroupPrimitive(spline_prims, SPLINE_STYLE);
+  return new GroupPrimitive(spline_prims, { style: SPLINE_STYLE });
 }
 
 export const sketch = (p) => {

--- a/Coral/rendering.js
+++ b/Coral/rendering.js
@@ -1,5 +1,8 @@
 import { Point } from "../pga2d/objects.js";
-import { LinePrimitive, RectPrimitive } from "../sketchlib/primitives.js";
+import {
+  LinePrimitive,
+  RectPrimitive,
+} from "../sketchlib/rendering/primitives.js";
 import { Rect } from "./Rect.js";
 import { CoralTile } from "./CoralTile.js";
 import { Direction } from "../sketchlib/Direction.js";

--- a/DifferentialGrowth/DifferentialGrowth.js
+++ b/DifferentialGrowth/DifferentialGrowth.js
@@ -2,7 +2,7 @@ import { Rectangle } from "./rectangle.js";
 import { Quadtree } from "./quadtree.js";
 import { DifferentialPolyline } from "./DifferentialPolyline.js";
 import { Style } from "../sketchlib/Style.js";
-import { draw_primitive } from "../sketchlib/draw_primitive.js";
+import { draw_primitive } from "../sketchlib/p5_helpers/draw_primitive.js";
 import { Vector2 } from "./Vector2.js";
 import { HEIGHT, WIDTH } from "../sketchlib/dimensions.js";
 import { Color } from "../sketchlib/Color.js";

--- a/DifferentialGrowth/DifferentialPolyline.js
+++ b/DifferentialGrowth/DifferentialPolyline.js
@@ -4,7 +4,7 @@ import {
   BezierPrimitive,
   GroupPrimitive,
   PolygonPrimitive,
-} from "../sketchlib/primitives.js";
+} from "../sketchlib/rendering/primitives.js";
 import { Random } from "../sketchlib/random.js";
 import { Vector2 } from "./Vector2.js";
 import { DifferentialNode, NEARBY_RADIUS } from "./DifferentialNode.js";

--- a/DifferentialGrowth/DifferentialPolyline.js
+++ b/DifferentialGrowth/DifferentialPolyline.js
@@ -1,8 +1,6 @@
 import { Point } from "../pga2d/objects.js";
 import {
   BeziergonPrimitive,
-  BezierPrimitive,
-  GroupPrimitive,
   PolygonPrimitive,
 } from "../sketchlib/rendering/primitives.js";
 import { Random } from "../sketchlib/random.js";
@@ -11,6 +9,7 @@ import { DifferentialNode, NEARBY_RADIUS } from "./DifferentialNode.js";
 import { Circle } from "./circle.js";
 import { mod } from "../sketchlib/mod.js";
 import { HEIGHT, WIDTH } from "../sketchlib/dimensions.js";
+import { GroupPrimitive } from "../sketchlib/rendering/GroupPrimitive.js";
 
 const MAX_EDGE_LENGTH = 150;
 
@@ -232,7 +231,7 @@ export class DifferentialPolyline {
     );
 
     const beziergon = BeziergonPrimitive.interpolate_points(positions);
-    return new GroupPrimitive([beziergon], style);
+    return new GroupPrimitive(beziergon, { style });
   }
 
   make_polyline(style) {
@@ -240,7 +239,7 @@ export class DifferentialPolyline {
       Point.point(x.position.x, x.position.y)
     );
     const polygon = new PolygonPrimitive(vertices);
-    return new GroupPrimitive([polygon], style);
+    return new GroupPrimitive(polygon, { style });
   }
 
   draw(p, fill_color) {

--- a/MosaicSlider/InteractiveMosaic.js
+++ b/MosaicSlider/InteractiveMosaic.js
@@ -1,5 +1,5 @@
 import { Point } from "../pga2d/objects.js";
-import { GroupPrimitive } from "../sketchlib/primitives.js";
+import { GroupPrimitive } from "../sketchlib/rendering/primitives.js";
 import { Color } from "../sketchlib/Color.js";
 import { MosaicGrid } from "./MosaicGrid.js";
 

--- a/MosaicSlider/InteractiveMosaic.js
+++ b/MosaicSlider/InteractiveMosaic.js
@@ -1,6 +1,6 @@
 import { Point } from "../pga2d/objects.js";
-import { GroupPrimitive } from "../sketchlib/rendering/primitives.js";
 import { Color } from "../sketchlib/Color.js";
+import { GroupPrimitive } from "../sketchlib/rendering/GroupPrimitive.js";
 import { MosaicGrid } from "./MosaicGrid.js";
 
 const SliderState = {

--- a/MosaicSlider/MosaicGrid.js
+++ b/MosaicSlider/MosaicGrid.js
@@ -1,7 +1,10 @@
 import { Point } from "../pga2d/objects.js";
 import { Grid, Index2D } from "../sketchlib/Grid.js";
 import { HEIGHT, WIDTH } from "../sketchlib/dimensions.js";
-import { GroupPrimitive, RectPrimitive } from "../sketchlib/primitives.js";
+import {
+  GroupPrimitive,
+  RectPrimitive,
+} from "../sketchlib/rendering/primitives.js";
 import { Style } from "../sketchlib/Style.js";
 import { PixelSwapPair } from "./PixelSwapPair.js";
 import { in_bounds } from "../sketchlib/in_bounds.js";

--- a/MosaicSlider/MosaicGrid.js
+++ b/MosaicSlider/MosaicGrid.js
@@ -1,15 +1,13 @@
 import { Point } from "../pga2d/objects.js";
 import { Grid, Index2D } from "../sketchlib/Grid.js";
 import { HEIGHT, WIDTH } from "../sketchlib/dimensions.js";
-import {
-  GroupPrimitive,
-  RectPrimitive,
-} from "../sketchlib/rendering/primitives.js";
+import { RectPrimitive } from "../sketchlib/rendering/primitives.js";
 import { Style } from "../sketchlib/Style.js";
 import { PixelSwapPair } from "./PixelSwapPair.js";
 import { in_bounds } from "../sketchlib/in_bounds.js";
 import { sec_to_frames } from "../sketchlib/Tween.js";
 import { Color } from "../sketchlib/Color.js";
+import { GroupPrimitive } from "../sketchlib/rendering/GroupPrimitive.js";
 
 const ROWS = 16;
 const COLS = 16;
@@ -148,7 +146,7 @@ export class MosaicGrid {
       by_colors[color_index].push(rect);
     });
     const color_groups = by_colors.map((x, i) => {
-      return new GroupPrimitive(x, this.styles[i]);
+      return new GroupPrimitive(x, { style: this.styles[i] });
     });
     return new GroupPrimitive(color_groups);
   }

--- a/MosaicSlider/MosaicSlider.js
+++ b/MosaicSlider/MosaicSlider.js
@@ -1,6 +1,6 @@
 import { WIDTH, HEIGHT } from "../sketchlib/dimensions.js";
 import { Color } from "../sketchlib/Color.js";
-import { draw_primitive } from "../sketchlib/draw_primitive.js";
+import { draw_primitive } from "../sketchlib/p5_helpers/draw_primitive.js";
 import { fix_mouse_coords } from "../sketchlib/fix_mouse_coords.js";
 import { InteractiveMosaic } from "./InteractiveMosaic.js";
 import { prevent_mobile_scroll } from "../sketchlib/prevent_mobile_scroll.js";

--- a/MosaicSlider/PixelSwapPair.js
+++ b/MosaicSlider/PixelSwapPair.js
@@ -1,5 +1,8 @@
 import { Point } from "../pga2d/objects.js";
-import { GroupPrimitive, RectPrimitive } from "../sketchlib/primitives.js";
+import {
+  GroupPrimitive,
+  RectPrimitive,
+} from "../sketchlib/rendering/primitives.js";
 import { Style } from "../sketchlib/Style.js";
 import { Tween } from "../sketchlib/Tween.js";
 

--- a/MosaicSlider/PixelSwapPair.js
+++ b/MosaicSlider/PixelSwapPair.js
@@ -1,8 +1,6 @@
 import { Point } from "../pga2d/objects.js";
-import {
-  GroupPrimitive,
-  RectPrimitive,
-} from "../sketchlib/rendering/primitives.js";
+import { GroupPrimitive } from "../sketchlib/rendering/GroupPrimitive.js";
+import { RectPrimitive } from "../sketchlib/rendering/primitives.js";
 import { Style } from "../sketchlib/Style.js";
 import { Tween } from "../sketchlib/Tween.js";
 
@@ -67,8 +65,8 @@ export class PixelSwapPair {
     const square_b = new RectPrimitive(b_position, this.pixel_dimensions);
     const square_a = new RectPrimitive(a_position, this.pixel_dimensions);
 
-    const group_b = new GroupPrimitive([square_b], this.style_b);
-    const group_a = new GroupPrimitive([square_a], this.style_a);
+    const group_b = new GroupPrimitive([square_b], { style: this.style_b });
+    const group_a = new GroupPrimitive([square_a], { style: this.style_a });
 
     // square b must be rendered before square a so the pixel we want to
     // move is on top.

--- a/PerspectiveRailroad/PerspectiveRailroad.js
+++ b/PerspectiveRailroad/PerspectiveRailroad.js
@@ -5,7 +5,7 @@ import {
   GroupPrimitive,
 } from "../sketchlib/rendering/primitives.js";
 import { Style } from "../sketchlib/Style.js";
-import { draw_primitive } from "../sketchlib/draw_primitive.js";
+import { draw_primitive } from "../sketchlib/p5_helpers/draw_primitive.js";
 import { Color } from "../sketchlib/Color.js";
 
 const WIDTH = 500;

--- a/PerspectiveRailroad/PerspectiveRailroad.js
+++ b/PerspectiveRailroad/PerspectiveRailroad.js
@@ -3,7 +3,7 @@ import {
   PolygonPrimitive,
   RectPrimitive,
   GroupPrimitive,
-} from "../sketchlib/primitives.js";
+} from "../sketchlib/rendering/primitives.js";
 import { Style } from "../sketchlib/Style.js";
 import { draw_primitive } from "../sketchlib/draw_primitive.js";
 import { Color } from "../sketchlib/Color.js";

--- a/PerspectiveRailroad/PerspectiveRailroad.js
+++ b/PerspectiveRailroad/PerspectiveRailroad.js
@@ -2,11 +2,11 @@ import { Line, Point } from "../pga2d/objects.js";
 import {
   PolygonPrimitive,
   RectPrimitive,
-  GroupPrimitive,
 } from "../sketchlib/rendering/primitives.js";
 import { Style } from "../sketchlib/Style.js";
 import { draw_primitive } from "../sketchlib/p5_helpers/draw_primitive.js";
 import { Color } from "../sketchlib/Color.js";
+import { GroupPrimitive } from "../sketchlib/rendering/GroupPrimitive.js";
 
 const WIDTH = 500;
 const HEIGHT = 700;
@@ -166,13 +166,13 @@ function make_background() {
     Point.point(0, 0),
     Point.direction(WIDTH, VP_RAILS.y)
   );
-  const sky = new GroupPrimitive([sky_prim], SKY_STYLE);
+  const sky = new GroupPrimitive(sky_prim, { style: SKY_STYLE });
 
   const ground_prim = new RectPrimitive(
     Point.point(0, VP_RAILS.y),
     Point.direction(WIDTH, HEIGHT - VP_RAILS.y)
   );
-  const ground = new GroupPrimitive([ground_prim], GROUND_STYLE);
+  const ground = new GroupPrimitive(ground_prim, { style: GROUND_STYLE });
 
   return new GroupPrimitive([sky, ground]);
 }
@@ -240,6 +240,12 @@ function make_ties() {
 }
 
 class AnimatedRails {
+  /**
+   * Constructor
+   * @param {PolygonPrimitive[]} triangles Perspective triangles that make up parts of the rail
+   * @param {number} start_frame First frame of the animation
+   * @param {number} duration_frames Duration of the animation in frames
+   */
   constructor(triangles, start_frame, duration_frames) {
     triangles.forEach((x) => {
       if (x.vertices.length !== 3) {
@@ -303,10 +309,10 @@ export const sketch = (p) => {
     const tie_prims = ANIMATED_TIES.map((x) =>
       x.compute_polygon(p.frameCount)
     ).filter((x) => x !== undefined);
-    const ties = new GroupPrimitive(tie_prims, TIE_STYLE);
+    const ties = new GroupPrimitive(tie_prims, { style: TIE_STYLE });
 
     const rail_prims = ANIMATED_RAILS.compute_polygons(p.frameCount);
-    const rails = new GroupPrimitive(rail_prims, RAIL_STYLE);
+    const rails = new GroupPrimitive(rail_prims, { style: RAIL_STYLE });
 
     const dynamic_geom = new GroupPrimitive([ties, rails]);
 

--- a/Worm/AnimatedWorm.js
+++ b/Worm/AnimatedWorm.js
@@ -5,7 +5,7 @@ import {
   GroupPrimitive,
   LinePrimitive,
   PointPrimitive,
-} from "../sketchlib/primitives.js";
+} from "../sketchlib/rendering/primitives.js";
 import { Style } from "../sketchlib/Style.js";
 import { Color } from "../sketchlib/Color.js";
 import { Motor } from "../pga2d/versors.js";

--- a/Worm/AnimatedWorm.js
+++ b/Worm/AnimatedWorm.js
@@ -2,7 +2,6 @@ import { Point } from "../pga2d/objects.js";
 import {
   BeziergonPrimitive,
   CirclePrimitive,
-  GroupPrimitive,
   LinePrimitive,
   PointPrimitive,
 } from "../sketchlib/rendering/primitives.js";
@@ -12,6 +11,7 @@ import { Motor } from "../pga2d/versors.js";
 import { AnimationChain, Joint } from "../sketchlib/AnimationChain.js";
 import { is_nearly } from "../sketchlib/is_nearly.js";
 import { GooglyEye } from "./GooglyEye.js";
+import { GroupPrimitive } from "../sketchlib/rendering/GroupPrimitive.js";
 
 const WORM_SEGMENTS = 60;
 const WORM_SEGMENT_SEPARATION = 30;
@@ -120,10 +120,10 @@ export class AnimatedWorm {
     for (let i = 0; i < lines.length; i++) {
       lines[i] = new LinePrimitive(positions[i], positions[i + 1]);
     }
-    const spine_group = new GroupPrimitive(lines, SPINE_STYLE);
+    const spine_group = new GroupPrimitive(lines, { style: SPINE_STYLE });
 
     const centers = positions.map((x) => new PointPrimitive(x));
-    const centers_group = new GroupPrimitive(centers, CENTER_STYLE);
+    const centers_group = new GroupPrimitive(centers, { style: CENTER_STYLE });
 
     return new GroupPrimitive([spine_group, centers_group]);
   }
@@ -199,7 +199,7 @@ export class AnimatedWorm {
     const all_points = left.concat(tail_points, right, head_points);
     const beziergon = BeziergonPrimitive.interpolate_points(all_points);
 
-    return new GroupPrimitive([beziergon], WORM_STYLE);
+    return new GroupPrimitive(beziergon, { style: WORM_STYLE });
   }
 
   render_eyes() {

--- a/Worm/GooglyEye.js
+++ b/Worm/GooglyEye.js
@@ -1,6 +1,9 @@
 import { Point } from "../pga2d/objects.js";
 import { Color } from "../sketchlib/Color.js";
-import { CirclePrimitive, GroupPrimitive } from "../sketchlib/primitives.js";
+import {
+  CirclePrimitive,
+  GroupPrimitive,
+} from "../sketchlib/rendering/primitives.js";
 import { Style } from "../sketchlib/Style.js";
 
 const STYLE_SCLERA = new Style({ fill: Color.WHITE });

--- a/Worm/GooglyEye.js
+++ b/Worm/GooglyEye.js
@@ -1,9 +1,7 @@
 import { Point } from "../pga2d/objects.js";
 import { Color } from "../sketchlib/Color.js";
-import {
-  CirclePrimitive,
-  GroupPrimitive,
-} from "../sketchlib/rendering/primitives.js";
+import { GroupPrimitive } from "../sketchlib/rendering/GroupPrimitive.js";
+import { CirclePrimitive } from "../sketchlib/rendering/primitives.js";
 import { Style } from "../sketchlib/Style.js";
 
 const STYLE_SCLERA = new Style({ fill: Color.WHITE });
@@ -37,13 +35,13 @@ export class GooglyEye {
       this.position,
       this.sclera_radius
     );
-    const sclera = new GroupPrimitive([sclera_circle], STYLE_SCLERA);
+    const sclera = new GroupPrimitive(sclera_circle, { style: STYLE_SCLERA });
 
     const pupil_center = this.position.add(
       this.look_direction.scale(this.sclera_radius - this.pupil_radius)
     );
     const pupil_circle = new CirclePrimitive(pupil_center, this.pupil_radius);
-    const pupil = new GroupPrimitive([pupil_circle], STYLE_PUPIL);
+    const pupil = new GroupPrimitive(pupil_circle, { style: STYLE_PUPIL });
 
     return new GroupPrimitive([sclera, pupil]);
   }

--- a/Worm/Worm.js
+++ b/Worm/Worm.js
@@ -1,7 +1,7 @@
 import { WIDTH, HEIGHT } from "../sketchlib/dimensions.js";
 import { fix_mouse_coords } from "../sketchlib/fix_mouse_coords.js";
 
-import { draw_primitive } from "../sketchlib/draw_primitive.js";
+import { draw_primitive } from "../sketchlib/p5_helpers/draw_primitive.js";
 import { Point } from "../pga2d/objects.js";
 import { AnimatedWorm } from "./AnimatedWorm.js";
 import { prevent_mobile_scroll } from "../sketchlib/prevent_mobile_scroll.js";

--- a/lab/ButtonLab/ButtonLab.js
+++ b/lab/ButtonLab/ButtonLab.js
@@ -2,7 +2,10 @@ import { Point } from "../../pga2d/objects.js";
 import { WIDTH, HEIGHT, SCREEN_CENTER } from "../../sketchlib/dimensions.js";
 import { to_y_down } from "../../sketchlib/Direction.js";
 import { draw_primitive } from "../../sketchlib/draw_primitive.js";
-import { CirclePrimitive, GroupPrimitive } from "../../sketchlib/primitives.js";
+import {
+  CirclePrimitive,
+  GroupPrimitive,
+} from "../../sketchlib/rendering/primitives.js";
 import { Style } from "../../sketchlib/Style.js";
 import { CanvasMouseHandler } from "../lablib/CanvasMouseHandler.js";
 import { TouchDPad } from "../lablib/TouchDPad.js";

--- a/lab/ButtonLab/ButtonLab.js
+++ b/lab/ButtonLab/ButtonLab.js
@@ -2,17 +2,15 @@ import { Point } from "../../pga2d/objects.js";
 import { WIDTH, HEIGHT, SCREEN_CENTER } from "../../sketchlib/dimensions.js";
 import { to_y_down } from "../../sketchlib/Direction.js";
 import { draw_primitive } from "../../sketchlib/p5_helpers/draw_primitive.js";
-import {
-  CirclePrimitive,
-  GroupPrimitive,
-} from "../../sketchlib/rendering/primitives.js";
+import { CirclePrimitive } from "../../sketchlib/rendering/primitives.js";
 import { Style } from "../../sketchlib/Style.js";
 import { CanvasMouseHandler } from "../lablib/CanvasMouseHandler.js";
 import { TouchDPad } from "../lablib/TouchDPad.js";
 import { Rectangle } from "../lablib/Rectangle.js";
-import { ButtonState, TouchButton } from "../lablib/TouchButton.js";
+import { TouchButton } from "../lablib/TouchButton.js";
 import { ToggleButton, ToggleState } from "../lablib/ToggleButton.js";
 import { Color } from "../../sketchlib/Color.js";
+import { GroupPrimitive } from "../../sketchlib/rendering/GroupPrimitive.js";
 
 const MOUSE = new CanvasMouseHandler();
 const DPAD = new TouchDPad(
@@ -61,7 +59,7 @@ export const sketch = (p) => {
       : Style.DEFAULT_STROKE_FILL;
 
     const circle = new CirclePrimitive(position, 20);
-    const circle_group = new GroupPrimitive([circle], style);
+    const circle_group = new GroupPrimitive(circle, { style });
     const dpad = DPAD.render();
     const button = BUTTON.debug_render();
     const toggle = TOGGLE.debug_render();

--- a/lab/ButtonLab/ButtonLab.js
+++ b/lab/ButtonLab/ButtonLab.js
@@ -1,7 +1,7 @@
 import { Point } from "../../pga2d/objects.js";
 import { WIDTH, HEIGHT, SCREEN_CENTER } from "../../sketchlib/dimensions.js";
 import { to_y_down } from "../../sketchlib/Direction.js";
-import { draw_primitive } from "../../sketchlib/draw_primitive.js";
+import { draw_primitive } from "../../sketchlib/p5_helpers/draw_primitive.js";
 import {
   CirclePrimitive,
   GroupPrimitive,

--- a/lab/DoublePendulum/DoublePendulum.js
+++ b/lab/DoublePendulum/DoublePendulum.js
@@ -1,7 +1,7 @@
 import { Point } from "../../pga2d/objects.js";
 import { WIDTH, HEIGHT } from "../../sketchlib/dimensions.js";
 import { draw_primitive } from "../../sketchlib/draw_primitive.js";
-import { GroupPrimitive } from "../../sketchlib/primitives.js";
+import { GroupPrimitive } from "../../sketchlib/rendering/primitives.js";
 import { DoublePendulumSystem, Pendulum } from "./DoublePendulumSystem.js";
 
 const BOB_MASS = 1.0;

--- a/lab/DoublePendulum/DoublePendulum.js
+++ b/lab/DoublePendulum/DoublePendulum.js
@@ -1,6 +1,6 @@
 import { Point } from "../../pga2d/objects.js";
 import { WIDTH, HEIGHT } from "../../sketchlib/dimensions.js";
-import { draw_primitive } from "../../sketchlib/draw_primitive.js";
+import { draw_primitive } from "../../sketchlib/p5_helpers/draw_primitive.js";
 import { GroupPrimitive } from "../../sketchlib/rendering/primitives.js";
 import { DoublePendulumSystem, Pendulum } from "./DoublePendulumSystem.js";
 

--- a/lab/DoublePendulum/DoublePendulum.js
+++ b/lab/DoublePendulum/DoublePendulum.js
@@ -1,7 +1,7 @@
 import { Point } from "../../pga2d/objects.js";
 import { WIDTH, HEIGHT } from "../../sketchlib/dimensions.js";
 import { draw_primitive } from "../../sketchlib/p5_helpers/draw_primitive.js";
-import { GroupPrimitive } from "../../sketchlib/rendering/primitives.js";
+import { GroupPrimitive } from "../../sketchlib/rendering/GroupPrimitive.js";
 import { DoublePendulumSystem, Pendulum } from "./DoublePendulumSystem.js";
 
 const BOB_MASS = 1.0;

--- a/lab/DoublePendulum/DoublePendulumSystem.js
+++ b/lab/DoublePendulum/DoublePendulumSystem.js
@@ -3,7 +3,7 @@ import {
   CirclePrimitive,
   GroupPrimitive,
   LinePrimitive,
-} from "../../sketchlib/primitives.js";
+} from "../../sketchlib/rendering/primitives.js";
 import { RungeKuttaIntegrator } from "../lablib/RungeKuttaIntegrator.js";
 import { Style } from "../../sketchlib/Style.js";
 import { RingBuffer } from "../lablib/RingBuffer.js";

--- a/lab/DoublePendulum/DoublePendulumSystem.js
+++ b/lab/DoublePendulum/DoublePendulumSystem.js
@@ -1,7 +1,6 @@
 import { Point } from "../../pga2d/objects.js";
 import {
   CirclePrimitive,
-  GroupPrimitive,
   LinePrimitive,
 } from "../../sketchlib/rendering/primitives.js";
 import { RungeKuttaIntegrator } from "../lablib/RungeKuttaIntegrator.js";
@@ -11,6 +10,7 @@ import { GeneralizedCoordinates } from "../lablib/VectorSpace.js";
 import { PI, TAU } from "../../sketchlib/math_consts.js";
 import { mod } from "../../sketchlib/mod.js";
 import { Color } from "../../sketchlib/Color.js";
+import { GroupPrimitive } from "../../sketchlib/rendering/GroupPrimitive.js";
 
 const STYLE_AXIS = Style.DEFAULT_STROKE.with_width(2);
 const ARM_STYLE = STYLE_AXIS;
@@ -169,8 +169,8 @@ export class DoublePendulumSystem {
     }
 
     return [
-      new GroupPrimitive(phase1, STYLE_PHASE1),
-      new GroupPrimitive(phase2, STYLE_PHASE2),
+      new GroupPrimitive(phase1, { style: STYLE_PHASE1 }),
+      new GroupPrimitive(phase2, { style: STYLE_PHASE2 }),
     ];
   }
 
@@ -190,7 +190,7 @@ export class DoublePendulumSystem {
       new LinePrimitive(origin.sub(theta_dot_dir), origin.add(theta_dot_dir)),
     ];
 
-    return new GroupPrimitive(primitives, STYLE_AXIS);
+    return new GroupPrimitive(primitives, { style: STYLE_AXIS });
   }
 
   angles_to_positions(origin, theta1, theta2) {
@@ -227,8 +227,8 @@ export class DoublePendulumSystem {
     }
 
     return [
-      new GroupPrimitive(history1, STYLE_PHASE1),
-      new GroupPrimitive(history2, STYLE_PHASE2),
+      new GroupPrimitive(history1, { style: STYLE_PHASE1 }),
+      new GroupPrimitive(history2, { style: STYLE_PHASE2 }),
     ];
   }
 
@@ -257,6 +257,6 @@ export class DoublePendulumSystem {
       PIXELS_PER_METER * this.pendulum2.bob_radius
     );
 
-    return new GroupPrimitive([arm1, arm2, bob1, bob2], ARM_STYLE);
+    return new GroupPrimitive([arm1, arm2, bob1, bob2], { style: ARM_STYLE });
   }
 }

--- a/lab/DoubleSpring/DoubleSpring.js
+++ b/lab/DoubleSpring/DoubleSpring.js
@@ -1,7 +1,7 @@
 import { Point } from "../../pga2d/objects.js";
 import { WIDTH, HEIGHT } from "../../sketchlib/dimensions.js";
 import { draw_primitive } from "../../sketchlib/p5_helpers/draw_primitive.js";
-import { GroupPrimitive } from "../../sketchlib/rendering/primitives.js";
+import { GroupPrimitive } from "../../sketchlib/rendering/GroupPrimitive.js";
 import { Oklch } from "../lablib/Oklch.js";
 import { DoubleSpringSystem, Spring } from "./DoubleSpringSystem.js";
 

--- a/lab/DoubleSpring/DoubleSpring.js
+++ b/lab/DoubleSpring/DoubleSpring.js
@@ -1,7 +1,7 @@
 import { Point } from "../../pga2d/objects.js";
 import { WIDTH, HEIGHT } from "../../sketchlib/dimensions.js";
 import { draw_primitive } from "../../sketchlib/draw_primitive.js";
-import { GroupPrimitive } from "../../sketchlib/primitives.js";
+import { GroupPrimitive } from "../../sketchlib/rendering/primitives.js";
 import { Oklch } from "../lablib/Oklch.js";
 import { DoubleSpringSystem, Spring } from "./DoubleSpringSystem.js";
 

--- a/lab/DoubleSpring/DoubleSpring.js
+++ b/lab/DoubleSpring/DoubleSpring.js
@@ -1,6 +1,6 @@
 import { Point } from "../../pga2d/objects.js";
 import { WIDTH, HEIGHT } from "../../sketchlib/dimensions.js";
-import { draw_primitive } from "../../sketchlib/draw_primitive.js";
+import { draw_primitive } from "../../sketchlib/p5_helpers/draw_primitive.js";
 import { GroupPrimitive } from "../../sketchlib/rendering/primitives.js";
 import { Oklch } from "../lablib/Oklch.js";
 import { DoubleSpringSystem, Spring } from "./DoubleSpringSystem.js";

--- a/lab/DoubleSpring/DoubleSpringSystem.js
+++ b/lab/DoubleSpring/DoubleSpringSystem.js
@@ -3,7 +3,7 @@ import {
   GroupPrimitive,
   LinePrimitive,
   RectPrimitive,
-} from "../../sketchlib/primitives.js";
+} from "../../sketchlib/rendering/primitives.js";
 import { RungeKuttaIntegrator } from "../lablib/RungeKuttaIntegrator.js";
 import { Style } from "../../sketchlib/Style.js";
 import { RingBuffer } from "../lablib/RingBuffer.js";

--- a/lab/DoubleSpring/DoubleSpringSystem.js
+++ b/lab/DoubleSpring/DoubleSpringSystem.js
@@ -1,6 +1,5 @@
 import { Point } from "../../pga2d/objects.js";
 import {
-  GroupPrimitive,
   LinePrimitive,
   RectPrimitive,
 } from "../../sketchlib/rendering/primitives.js";
@@ -9,6 +8,7 @@ import { Style } from "../../sketchlib/Style.js";
 import { RingBuffer } from "../lablib/RingBuffer.js";
 import { GeneralizedCoordinates } from "../lablib/VectorSpace.js";
 import { Oklch } from "../lablib/Oklch.js";
+import { GroupPrimitive } from "../../sketchlib/rendering/GroupPrimitive.js";
 
 const PIXELS_PER_METER = 100;
 const X_METERS = Point.DIR_X.scale(PIXELS_PER_METER);
@@ -66,7 +66,7 @@ function render_horizontal_spring(position, dimensions, num_coils, style) {
     const diag_up = new LinePrimitive(b, c);
     wires.push(diag_down, diag_up);
   }
-  return new GroupPrimitive(wires, style);
+  return new GroupPrimitive(wires, { style });
 }
 
 export class DoubleSpringSystem {
@@ -145,8 +145,8 @@ export class DoubleSpringSystem {
     }
 
     return [
-      new GroupPrimitive(phase1, this.spring1.spring_style),
-      new GroupPrimitive(phase2, this.spring2.spring_style),
+      new GroupPrimitive(phase1, { style: this.spring1.spring_style }),
+      new GroupPrimitive(phase2, { style: this.spring2.spring_style }),
     ];
   }
 
@@ -166,7 +166,7 @@ export class DoubleSpringSystem {
       new LinePrimitive(origin.sub(v_dir), origin.add(v_dir)),
     ];
 
-    return new GroupPrimitive(primitives, STYLE_AXIS);
+    return new GroupPrimitive(primitives, { style: STYLE_AXIS });
   }
 
   /**
@@ -211,9 +211,13 @@ export class DoubleSpringSystem {
       this.spring2.spring_style
     );
 
-    const walls = new GroupPrimitive([wall, floor], STYLE_WALLS);
-    const left_bob = new GroupPrimitive([bob1], this.spring1.bob_style);
-    const right_bob = new GroupPrimitive([bob2], this.spring2.bob_style);
+    const walls = new GroupPrimitive([wall, floor], { style: STYLE_WALLS });
+    const left_bob = new GroupPrimitive(bob1, {
+      style: this.spring1.bob_style,
+    });
+    const right_bob = new GroupPrimitive(bob2, {
+      style: this.spring2.bob_style,
+    });
 
     return new GroupPrimitive([
       walls,

--- a/lab/PendulumClock/Clock.js
+++ b/lab/PendulumClock/Clock.js
@@ -2,9 +2,9 @@ import { Point } from "../../pga2d/objects.js";
 import { Color } from "../../sketchlib/Color.js";
 import { HEIGHT, WIDTH } from "../../sketchlib/dimensions.js";
 import { PI, TAU } from "../../sketchlib/math_consts.js";
+import { GroupPrimitive } from "../../sketchlib/rendering/GroupPrimitive.js";
 import {
   CirclePrimitive,
-  GroupPrimitive,
   LinePrimitive,
   VectorPrimitive,
 } from "../../sketchlib/rendering/primitives.js";
@@ -31,10 +31,9 @@ const STYLE_CLOCK = new Style({
   width: 5,
   fill: Color.WHITE,
 });
-const CLOCK_FACE = new GroupPrimitive(
-  [CLOCK_CIRCLE, ...CLOCK_HASHES],
-  STYLE_CLOCK
-);
+const CLOCK_FACE = new GroupPrimitive([CLOCK_CIRCLE, ...CLOCK_HASHES], {
+  style: STYLE_CLOCK,
+});
 
 const LENGTH_SECOND_HAND = (OUTER_RADIUS * 9) / 10;
 const LENGTH_MINUTE_HAND = (OUTER_RADIUS * 7) / 10;
@@ -87,8 +86,10 @@ function render_clock_hands(time) {
     width: 4,
   });
 
-  const hour_minute = new GroupPrimitive([hour_hand, minute_hand], style_hands);
-  const second = new GroupPrimitive([second_hand], style_second);
+  const hour_minute = new GroupPrimitive([hour_hand, minute_hand], {
+    style: style_hands,
+  });
+  const second = new GroupPrimitive(second_hand, { style: style_second });
   return new GroupPrimitive([hour_minute, second]);
 }
 
@@ -113,8 +114,8 @@ function render_pendulum(time) {
 
   const bob = new CirclePrimitive(bob_center, BOB_RADIUS);
 
-  const pendulum_arm = new GroupPrimitive([arm], STYLE_ARM);
-  const pendulum_bob = new GroupPrimitive([bob], STYLE_BOB);
+  const pendulum_arm = new GroupPrimitive(arm, { style: STYLE_ARM });
+  const pendulum_bob = new GroupPrimitive(bob, { style: STYLE_BOB });
   return new GroupPrimitive([pendulum_arm, pendulum_bob]);
 }
 

--- a/lab/PendulumClock/Clock.js
+++ b/lab/PendulumClock/Clock.js
@@ -7,7 +7,7 @@ import {
   GroupPrimitive,
   LinePrimitive,
   VectorPrimitive,
-} from "../../sketchlib/primitives.js";
+} from "../../sketchlib/rendering/primitives.js";
 import { Style } from "../../sketchlib/Style.js";
 import { ClockTime } from "./ClockTime.js";
 

--- a/lab/PendulumClock/PendulumClock.js
+++ b/lab/PendulumClock/PendulumClock.js
@@ -1,6 +1,6 @@
 import { WIDTH, HEIGHT } from "../../sketchlib/dimensions.js";
 import { draw_primitive } from "../../sketchlib/p5_helpers/draw_primitive.js";
-import { GroupPrimitive } from "../../sketchlib/rendering/primitives.js";
+import { GroupPrimitive } from "../../sketchlib/rendering/GroupPrimitive.js";
 import { CanvasMouseHandler } from "../lablib/CanvasMouseHandler.js";
 import { N16, N32, N8 } from "../lablib/music/durations.js";
 import { A3, C4, D4, E4, G4 } from "../lablib/music/pitches.js";

--- a/lab/PendulumClock/PendulumClock.js
+++ b/lab/PendulumClock/PendulumClock.js
@@ -1,6 +1,6 @@
 import { WIDTH, HEIGHT } from "../../sketchlib/dimensions.js";
 import { draw_primitive } from "../../sketchlib/draw_primitive.js";
-import { GroupPrimitive } from "../../sketchlib/primitives.js";
+import { GroupPrimitive } from "../../sketchlib/rendering/primitives.js";
 import { CanvasMouseHandler } from "../lablib/CanvasMouseHandler.js";
 import { N16, N32, N8 } from "../lablib/music/durations.js";
 import { A3, C4, D4, E4, G4 } from "../lablib/music/pitches.js";

--- a/lab/PendulumClock/PendulumClock.js
+++ b/lab/PendulumClock/PendulumClock.js
@@ -1,5 +1,5 @@
 import { WIDTH, HEIGHT } from "../../sketchlib/dimensions.js";
-import { draw_primitive } from "../../sketchlib/draw_primitive.js";
+import { draw_primitive } from "../../sketchlib/p5_helpers/draw_primitive.js";
 import { GroupPrimitive } from "../../sketchlib/rendering/primitives.js";
 import { CanvasMouseHandler } from "../lablib/CanvasMouseHandler.js";
 import { N16, N32, N8 } from "../lablib/music/durations.js";

--- a/lab/PixelMaze/PixelMaze.js
+++ b/lab/PixelMaze/PixelMaze.js
@@ -1,7 +1,7 @@
 import { Point } from "../../pga2d/objects.js";
 import { HEIGHT, WIDTH } from "../../sketchlib/dimensions.js";
 import { Direction } from "../../sketchlib/Direction.js";
-import { draw_primitive } from "../../sketchlib/draw_primitive.js";
+import { draw_primitive } from "../../sketchlib/p5_helpers/draw_primitive.js";
 import { CanvasMouseHandler } from "../lablib/CanvasMouseHandler.js";
 import { DirectionalPad, DirectionInput } from "../lablib/DirectionalPad.js";
 import { blit_sprite, blit_tilemap, P5Sprite, P5Tilemap } from "./blit.js";

--- a/lab/SoundTest/SoundTest.js
+++ b/lab/SoundTest/SoundTest.js
@@ -8,6 +8,7 @@ import {
   TextPrimitive,
 } from "../../sketchlib/rendering/primitives.js";
 import { TextStyle } from "../../sketchlib/rendering/TextStyle.js";
+import { Transform } from "../../sketchlib/rendering/Transform.js";
 import { Style } from "../../sketchlib/Style.js";
 import { CanvasMouseHandler } from "../lablib/CanvasMouseHandler.js";
 import { render_score } from "../lablib/music/render_score.js";
@@ -90,6 +91,16 @@ const BUTTON_LABELS = new GroupPrimitive([TEXT_A, TEXT_B, TEXT_C], {
   text_style: TEXT_STYLE,
 });
 
+const TIMELINE_TOP = HEIGHT / 8;
+
+const CURSOR = new GroupPrimitive(
+  new LinePrimitive(
+    Point.point(WIDTH / 2, TIMELINE_TOP),
+    Point.point(WIDTH / 2, TIMELINE_TOP + HEIGHT / 4)
+  ),
+  { style: Style.DEFAULT_STROKE }
+);
+
 class SoundScene {
   constructor(sound) {
     this.sound = sound;
@@ -156,13 +167,13 @@ class SoundScene {
     if (this.selected_melody !== undefined) {
       const current_time = SOUND.transport_time;
       const x = current_time * MEASURE_DIMENSIONS.x;
-
-      const cursor = new GroupPrimitive(
-        [new LinePrimitive(Point.point(x, 0), Point.point(x, WIDTH / 4))],
-        { style: Style.DEFAULT_STROKE }
+      const transform = new Transform(
+        Point.direction(WIDTH / 2 - x, TIMELINE_TOP)
       );
+      const timeline = RENDERED_TIMELINES[this.selected_melody];
+      const shifted = new GroupPrimitive(timeline, { transform });
 
-      primitives.push(RENDERED_TIMELINES[this.selected_melody], cursor);
+      return new GroupPrimitive([...primitives, shifted, CURSOR]);
     }
 
     return new GroupPrimitive(primitives);

--- a/lab/SoundTest/SoundTest.js
+++ b/lab/SoundTest/SoundTest.js
@@ -1,7 +1,7 @@
 import { Point } from "../../pga2d/objects.js";
 import { Color } from "../../sketchlib/Color.js";
 import { WIDTH, HEIGHT } from "../../sketchlib/dimensions.js";
-import { draw_primitive } from "../../sketchlib/draw_primitive.js";
+import { draw_primitive } from "../../sketchlib/p5_helpers/draw_primitive.js";
 import {
   GroupPrimitive,
   LinePrimitive,

--- a/lab/SoundTest/SoundTest.js
+++ b/lab/SoundTest/SoundTest.js
@@ -2,15 +2,15 @@ import { Point } from "../../pga2d/objects.js";
 import { Color } from "../../sketchlib/Color.js";
 import { WIDTH, HEIGHT } from "../../sketchlib/dimensions.js";
 import { draw_primitive } from "../../sketchlib/p5_helpers/draw_primitive.js";
+import { GroupPrimitive } from "../../sketchlib/rendering/GroupPrimitive.js";
 import {
-  GroupPrimitive,
   LinePrimitive,
   TextPrimitive,
-  TextStyle,
 } from "../../sketchlib/rendering/primitives.js";
+import { TextStyle } from "../../sketchlib/rendering/TextStyle.js";
 import { Style } from "../../sketchlib/Style.js";
 import { CanvasMouseHandler } from "../lablib/CanvasMouseHandler.js";
-import { render_score, render_timeline } from "../lablib/music/render_score.js";
+import { render_score } from "../lablib/music/render_score.js";
 import { MuteButton } from "../lablib/MuteButton.js";
 import { Oklch } from "../lablib/Oklch.js";
 import { PlayButtonScene } from "../lablib/PlayButtonScene.js";
@@ -68,6 +68,28 @@ const MELODY_BUTTON_DIMENSIONS = Point.direction(
   MELODY_BUTTON_SIZE
 );
 
+const TEXT_STYLE = new TextStyle(24, "center");
+const TEXT_A = new TextPrimitive(
+  "Melody A",
+  Point.point(MARGIN + MELODY_BUTTON_SIZE / 2, HEIGHT / 2)
+);
+const TEXT_B = new TextPrimitive(
+  "Melody B",
+  Point.point(WIDTH - MARGIN - MELODY_BUTTON_SIZE / 2, HEIGHT / 2)
+);
+const TEXT_C = new TextPrimitive(
+  "Melody C",
+  Point.point(MARGIN + MELODY_BUTTON_SIZE / 2, HEIGHT / 2 + MELODY_BUTTON_SIZE)
+);
+
+const TEXT_COLOR = new Style({
+  fill: Color.WHITE,
+});
+const BUTTON_LABELS = new GroupPrimitive([TEXT_A, TEXT_B, TEXT_C], {
+  style: TEXT_COLOR,
+  text_style: TEXT_STYLE,
+});
+
 class SoundScene {
   constructor(sound) {
     this.sound = sound;
@@ -121,33 +143,6 @@ class SoundScene {
       this.selected_melody = "melody_c";
       this.sound.play_score(this.selected_melody);
     });
-
-    const text_style = new TextStyle(24, "center");
-    const text_a = new TextPrimitive(
-      "Melody A",
-      Point.point(MARGIN + MELODY_BUTTON_SIZE / 2, HEIGHT / 2),
-      text_style
-    );
-    const text_b = new TextPrimitive(
-      "Melody B",
-      Point.point(WIDTH - MARGIN - MELODY_BUTTON_SIZE / 2, HEIGHT / 2),
-      text_style
-    );
-    const text_c = new TextPrimitive(
-      "Melody C",
-      Point.point(
-        MARGIN + MELODY_BUTTON_SIZE / 2,
-        HEIGHT / 2 + MELODY_BUTTON_SIZE
-      ),
-      text_style
-    );
-
-    this.button_labels = new GroupPrimitive(
-      [text_a, text_b, text_c],
-      new Style({
-        fill: Color.WHITE,
-      })
-    );
   }
 
   render() {
@@ -156,7 +151,7 @@ class SoundScene {
     const melody_b = this.melody_b_button.debug_render();
     const melody_c = this.melody_c_button.debug_render();
 
-    const primitives = [mute, melody_a, melody_b, melody_c, this.button_labels];
+    const primitives = [mute, melody_a, melody_b, melody_c, BUTTON_LABELS];
 
     if (this.selected_melody !== undefined) {
       const current_time = SOUND.transport_time;
@@ -164,7 +159,7 @@ class SoundScene {
 
       const cursor = new GroupPrimitive(
         [new LinePrimitive(Point.point(x, 0), Point.point(x, WIDTH / 4))],
-        Style.DEFAULT_STROKE
+        { style: Style.DEFAULT_STROKE }
       );
 
       primitives.push(RENDERED_TIMELINES[this.selected_melody], cursor);

--- a/lab/SoundTest/SoundTest.js
+++ b/lab/SoundTest/SoundTest.js
@@ -7,7 +7,7 @@ import {
   LinePrimitive,
   TextPrimitive,
   TextStyle,
-} from "../../sketchlib/primitives.js";
+} from "../../sketchlib/rendering/primitives.js";
 import { Style } from "../../sketchlib/Style.js";
 import { CanvasMouseHandler } from "../lablib/CanvasMouseHandler.js";
 import { render_score, render_timeline } from "../lablib/music/render_score.js";

--- a/lab/SoundTest/SoundTest.js
+++ b/lab/SoundTest/SoundTest.js
@@ -68,7 +68,7 @@ const MELODY_BUTTON_DIMENSIONS = Point.direction(
   MELODY_BUTTON_SIZE
 );
 
-const TEXT_STYLE = new TextStyle(24, "center");
+const TEXT_STYLE = new TextStyle(24, "center", "center");
 const TEXT_A = new TextPrimitive(
   "Melody A",
   Point.point(MARGIN + MELODY_BUTTON_SIZE / 2, HEIGHT / 2)

--- a/lab/SoundTest/index.html
+++ b/lab/SoundTest/index.html
@@ -29,8 +29,8 @@
         <dl>
           <dt>2025-05-28</dt>
           <dd>
-            I added a visualization of the musical timeline with a moving
-            cursor. It's a little basic so far, I may tweak this over time.
+            I added a visualization of the musical timeline to give a rough idea
+            of the structure of the music.
           </dd>
           <dt>2025-05-14</dt>
           <dd>
@@ -64,12 +64,6 @@
             nodes to make custom synthesizers, provide timing information so I
             could e.g. sync a visualization). This sketch will serve as a
             sandbox for experiments.
-          </li>
-          <li>
-            I'd like to make the timeline move to the left rather than the
-            cursor move to the right. To do this, I'll need to start adding
-            transformations (translations specifically) to my primitive
-            rendering system. Something I've been meaning to do for a while.
           </li>
           <li>
             For drawing loops in the timeline, to do so at a fine granularity

--- a/lab/lablib/DirectionalPad.js
+++ b/lab/lablib/DirectionalPad.js
@@ -1,6 +1,6 @@
 import { Point } from "../../pga2d/objects.js";
 import { HEIGHT } from "../../sketchlib/dimensions.js";
-import { GroupPrimitive } from "../../sketchlib/primitives.js";
+import { GroupPrimitive } from "../../sketchlib/rendering/primitives.js";
 import { DirectionInput } from "./DirectionInput.js";
 import { KeyboardDPad } from "./KeyboardDPad.js";
 import { MouseInput } from "./MouseInput.js";

--- a/lab/lablib/DirectionalPad.js
+++ b/lab/lablib/DirectionalPad.js
@@ -1,6 +1,6 @@
 import { Point } from "../../pga2d/objects.js";
 import { HEIGHT } from "../../sketchlib/dimensions.js";
-import { GroupPrimitive } from "../../sketchlib/rendering/primitives.js";
+import { GroupPrimitive } from "../../sketchlib/rendering/GroupPrimitive.js";
 import { DirectionInput } from "./DirectionInput.js";
 import { KeyboardDPad } from "./KeyboardDPad.js";
 import { MouseInput } from "./MouseInput.js";
@@ -31,7 +31,7 @@ export class DirectionalPad {
       return this.touch_dpad.render();
     }
 
-    return new GroupPrimitive([]);
+    return GroupPrimitive.EMPTY;
   }
 
   get direction() {

--- a/lab/lablib/MuteButton.js
+++ b/lab/lablib/MuteButton.js
@@ -5,7 +5,7 @@ import {
   GroupPrimitive,
   LinePrimitive,
   PolygonPrimitive,
-} from "../../sketchlib/primitives.js";
+} from "../../sketchlib/rendering/primitives.js";
 import { Style } from "../../sketchlib/Style.js";
 import { Rectangle } from "./Rectangle.js";
 import { ToggleButton, ToggleState } from "./ToggleButton.js";

--- a/lab/lablib/MuteButton.js
+++ b/lab/lablib/MuteButton.js
@@ -1,8 +1,8 @@
 import { Point } from "../../pga2d/objects.js";
 import { Color } from "../../sketchlib/Color.js";
 import { WIDTH } from "../../sketchlib/dimensions.js";
+import { GroupPrimitive } from "../../sketchlib/rendering/GroupPrimitive.js";
 import {
-  GroupPrimitive,
   LinePrimitive,
   PolygonPrimitive,
 } from "../../sketchlib/rendering/primitives.js";
@@ -49,21 +49,18 @@ const SPEAKER_BASE = new PolygonPrimitive([
   ),
 ]);
 
-const SPEAKER = new GroupPrimitive(
-  [SPEAKER_BASE, SPEAKER_CONE],
-  new Style({ stroke: Color.WHITE })
-);
+const SPEAKER = new GroupPrimitive([SPEAKER_BASE, SPEAKER_CONE], {
+  style: new Style({ stroke: Color.WHITE }),
+});
 
 const SPEAKER_SLASH = new GroupPrimitive(
-  [
-    new LinePrimitive(
-      SOUND_TOGGLE_CORNER.add(Point.direction(2, 2)),
-      SOUND_TOGGLE_CORNER.add(
-        Point.direction((3 * SOUND_TOGGLE_SIZE) / 4 - 2, SOUND_TOGGLE_SIZE - 2)
-      )
-    ),
-  ],
-  new Style({ stroke: Color.RED })
+  new LinePrimitive(
+    SOUND_TOGGLE_CORNER.add(Point.direction(2, 2)),
+    SOUND_TOGGLE_CORNER.add(
+      Point.direction((3 * SOUND_TOGGLE_SIZE) / 4 - 2, SOUND_TOGGLE_SIZE - 2)
+    )
+  ),
+  { style: new Style({ stroke: Color.RED }) }
 );
 const GROUP_MUTED = new GroupPrimitive([SPEAKER, SPEAKER_SLASH]);
 const GROUP_UNMUTED = SPEAKER;

--- a/lab/lablib/PlayButton.js
+++ b/lab/lablib/PlayButton.js
@@ -4,7 +4,7 @@ import { HEIGHT, WIDTH } from "../../sketchlib/dimensions.js";
 import {
   GroupPrimitive,
   PolygonPrimitive,
-} from "../../sketchlib/primitives.js";
+} from "../../sketchlib/rendering/primitives.js";
 import { Style } from "../../sketchlib/Style.js";
 import { SCREEN_RECT } from "./Rectangle.js";
 import { TouchButton } from "./TouchButton.js";

--- a/lab/lablib/PlayButton.js
+++ b/lab/lablib/PlayButton.js
@@ -1,10 +1,8 @@
 import { Point } from "../../pga2d/objects.js";
 import { Color } from "../../sketchlib/Color.js";
 import { HEIGHT, WIDTH } from "../../sketchlib/dimensions.js";
-import {
-  GroupPrimitive,
-  PolygonPrimitive,
-} from "../../sketchlib/rendering/primitives.js";
+import { GroupPrimitive } from "../../sketchlib/rendering/GroupPrimitive.js";
+import { PolygonPrimitive } from "../../sketchlib/rendering/primitives.js";
 import { Style } from "../../sketchlib/Style.js";
 import { SCREEN_RECT } from "./Rectangle.js";
 import { TouchButton } from "./TouchButton.js";
@@ -15,10 +13,9 @@ const PLAY_TRIANGLE = new PolygonPrimitive([
   Point.point(WIDTH / 2 - TRIANGLE_WIDTH / 2, HEIGHT / 2 + TRIANGLE_WIDTH / 2),
   Point.point(WIDTH / 2 + TRIANGLE_WIDTH / 2, HEIGHT / 2),
 ]);
-const PLAY_GROUP = new GroupPrimitive(
-  [PLAY_TRIANGLE],
-  new Style({ stroke: Color.WHITE })
-);
+const PLAY_GROUP = new GroupPrimitive([PLAY_TRIANGLE], {
+  style: new Style({ stroke: Color.WHITE }),
+});
 
 export class PlayButton {
   constructor() {

--- a/lab/lablib/ToggleButton.js
+++ b/lab/lablib/ToggleButton.js
@@ -1,9 +1,7 @@
 import { Point } from "../../pga2d/objects.js";
 import { Color } from "../../sketchlib/Color.js";
-import {
-  GroupPrimitive,
-  RectPrimitive,
-} from "../../sketchlib/rendering/primitives.js";
+import { GroupPrimitive } from "../../sketchlib/rendering/GroupPrimitive.js";
+import { RectPrimitive } from "../../sketchlib/rendering/primitives.js";
 import { Style } from "../../sketchlib/Style.js";
 import { Rectangle } from "./Rectangle.js";
 import { ButtonState, TouchButton } from "./TouchButton.js";
@@ -68,7 +66,7 @@ export class ToggleButton {
         ? Style.DEFAULT_FILL
         : new Style({ fill: Color.MAGENTA });
 
-    return new GroupPrimitive([rect], style);
+    return new GroupPrimitive(rect, { style });
   }
 
   /**

--- a/lab/lablib/ToggleButton.js
+++ b/lab/lablib/ToggleButton.js
@@ -1,6 +1,9 @@
 import { Point } from "../../pga2d/objects.js";
 import { Color } from "../../sketchlib/Color.js";
-import { GroupPrimitive, RectPrimitive } from "../../sketchlib/primitives.js";
+import {
+  GroupPrimitive,
+  RectPrimitive,
+} from "../../sketchlib/rendering/primitives.js";
 import { Style } from "../../sketchlib/Style.js";
 import { Rectangle } from "./Rectangle.js";
 import { ButtonState, TouchButton } from "./TouchButton.js";

--- a/lab/lablib/TouchButton.js
+++ b/lab/lablib/TouchButton.js
@@ -1,9 +1,7 @@
 import { Point } from "../../pga2d/objects.js";
 import { Color } from "../../sketchlib/Color.js";
-import {
-  GroupPrimitive,
-  RectPrimitive,
-} from "../../sketchlib/rendering/primitives.js";
+import { GroupPrimitive } from "../../sketchlib/rendering/GroupPrimitive.js";
+import { RectPrimitive } from "../../sketchlib/rendering/primitives.js";
 import { Style } from "../../sketchlib/Style.js";
 import { Rectangle } from "./Rectangle.js";
 
@@ -56,8 +54,9 @@ export class TouchButton {
 
   debug_render() {
     const rect = new RectPrimitive(this.rect.position, this.rect.dimensions);
+    const style = this.get_debug_style();
 
-    return new GroupPrimitive([rect], this.get_debug_style());
+    return new GroupPrimitive(rect, { style });
   }
 
   /**

--- a/lab/lablib/TouchButton.js
+++ b/lab/lablib/TouchButton.js
@@ -1,6 +1,9 @@
 import { Point } from "../../pga2d/objects.js";
 import { Color } from "../../sketchlib/Color.js";
-import { GroupPrimitive, RectPrimitive } from "../../sketchlib/primitives.js";
+import {
+  GroupPrimitive,
+  RectPrimitive,
+} from "../../sketchlib/rendering/primitives.js";
 import { Style } from "../../sketchlib/Style.js";
 import { Rectangle } from "./Rectangle.js";
 

--- a/lab/lablib/TouchDPad.js
+++ b/lab/lablib/TouchDPad.js
@@ -5,7 +5,7 @@ import {
   PolygonPrimitive,
   RectPrimitive,
   VectorPrimitive,
-} from "../../sketchlib/primitives.js";
+} from "../../sketchlib/rendering/primitives.js";
 import { Style } from "../../sketchlib/Style.js";
 import { DirectionInput } from "./DirectionInput.js";
 import { MouseInCanvas, MouseInput } from "./MouseInput.js";

--- a/lab/lablib/TouchDPad.js
+++ b/lab/lablib/TouchDPad.js
@@ -1,7 +1,7 @@
 import { Point } from "../../pga2d/objects.js";
 import { Direction, to_y_down } from "../../sketchlib/Direction.js";
+import { GroupPrimitive } from "../../sketchlib/rendering/GroupPrimitive.js";
 import {
-  GroupPrimitive,
   PolygonPrimitive,
   RectPrimitive,
   VectorPrimitive,
@@ -187,8 +187,10 @@ export class TouchDPad {
     const STYLE_IDLE = Style.DEFAULT_STROKE.with_width(2);
     const STYLE_PRESSED = Style.DEFAULT_STROKE_FILL.with_width(2);
 
-    const idle_group = new GroupPrimitive(idle_buttons, STYLE_IDLE);
-    const pressed_group = new GroupPrimitive(pressed_buttons, STYLE_PRESSED);
+    const idle_group = new GroupPrimitive(idle_buttons, { style: STYLE_IDLE });
+    const pressed_group = new GroupPrimitive(pressed_buttons, {
+      style: STYLE_PRESSED,
+    });
 
     return new GroupPrimitive([idle_group, pressed_group]);
   }
@@ -218,9 +220,8 @@ export class TouchDPad {
       center.add(digital_offset)
     );
 
-    return new GroupPrimitive(
-      [boundary, analog_arrow, digital_arrow],
-      Style.DEFAULT_STROKE
-    );
+    return new GroupPrimitive([boundary, analog_arrow, digital_arrow], {
+      style: Style.DEFAULT_STROKE,
+    });
   }
 }

--- a/lab/lablib/music/render_score.js
+++ b/lab/lablib/music/render_score.js
@@ -1,8 +1,6 @@
 import { Point } from "../../../pga2d/objects.js";
-import {
-  GroupPrimitive,
-  RectPrimitive,
-} from "../../../sketchlib/rendering/primitives.js";
+import { GroupPrimitive } from "../../../sketchlib/rendering/GroupPrimitive.js";
+import { RectPrimitive } from "../../../sketchlib/rendering/primitives.js";
 import { Style } from "../../../sketchlib/Style.js";
 import { count_voices } from "./count_voices.js";
 import { Harmony, Score } from "./Score.js";
@@ -34,7 +32,7 @@ function render_block(offset, timeline, measure_dimensions) {
  * @param {Point} offset The top left corner where the timeline should be rendered.
  * @param {import("./Timeline.js").Timeline<T>} timeline The timeline of events
  * @param {Point} measure_dimensions Dimensions of a 1 measure x 1 voice block in pixels as a Point.direction
- * @return {import("../../../sketchlib/rendering/primitives.js").Primitive | undefined} A primitive to render, or undefined if there was no content to render.
+ * @return {import("../../../sketchlib/rendering/GroupPrimitive.js").Primitive | undefined} A primitive to render, or undefined if there was no content to render.
  */
 export function render_timeline(offset, timeline, measure_dimensions) {
   if (timeline instanceof Gap) {
@@ -107,7 +105,7 @@ export function render_score(offset, score, measure_dimensions, styles) {
       part,
       measure_dimensions
     );
-    const part_group = new GroupPrimitive([rendered], styles[i]);
+    const part_group = new GroupPrimitive(rendered, { style: styles[i] });
     parts.push(part_group);
 
     voices_so_far += count_voices(part);

--- a/lab/lablib/music/render_score.js
+++ b/lab/lablib/music/render_score.js
@@ -2,7 +2,7 @@ import { Point } from "../../../pga2d/objects.js";
 import {
   GroupPrimitive,
   RectPrimitive,
-} from "../../../sketchlib/primitives.js";
+} from "../../../sketchlib/rendering/primitives.js";
 import { Style } from "../../../sketchlib/Style.js";
 import { count_voices } from "./count_voices.js";
 import { Harmony, Score } from "./Score.js";
@@ -34,7 +34,7 @@ function render_block(offset, timeline, measure_dimensions) {
  * @param {Point} offset The top left corner where the timeline should be rendered.
  * @param {import("./Timeline.js").Timeline<T>} timeline The timeline of events
  * @param {Point} measure_dimensions Dimensions of a 1 measure x 1 voice block in pixels as a Point.direction
- * @return {import("../../../sketchlib/primitives.js").Primitive | undefined} A primitive to render, or undefined if there was no content to render.
+ * @return {import("../../../sketchlib/rendering/primitives.js").Primitive | undefined} A primitive to render, or undefined if there was no content to render.
  */
 export function render_timeline(offset, timeline, measure_dimensions) {
   if (timeline instanceof Gap) {

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,8 +9,9 @@
       "version": "1.0.0",
       "license": "Apache-2.0",
       "devDependencies": {
-        "tone": "^15.1.22",
-        "vitest": "^3.0.5"
+        "p5": "^2.0.2",
+        "tone": "^15.2.6",
+        "vitest": "^3.1.4"
       }
     },
     "node_modules/@babel/runtime": {
@@ -26,10 +27,17 @@
         "node": ">=6.9.0"
       }
     },
+    "node_modules/@davepagurek/bezier-path": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/@davepagurek/bezier-path/-/bezier-path-0.0.2.tgz",
+      "integrity": "sha512-4L9ddgzZc9DRGyl1RrS3z5nwnVJoyjsAelVG4X1jh4tVxryEHr4H9QavhxW/my6Rn3669Qz6mhv8gd5O/WeFTA==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@esbuild/aix-ppc64": {
-      "version": "0.25.3",
-      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.25.3.tgz",
-      "integrity": "sha512-W8bFfPA8DowP8l//sxjJLSLkD8iEjMc7cBVyP+u4cEv9sM7mdUCkgsj+t0n/BWPFtv7WWCN5Yzj0N6FJNUUqBQ==",
+      "version": "0.25.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.25.5.tgz",
+      "integrity": "sha512-9o3TMmpmftaCMepOdA5k/yDw8SfInyzWWTjYTFCX3kPSDJMROQTb8jg+h9Cnwnmm1vOzvxN7gIfB5V2ewpjtGA==",
       "cpu": [
         "ppc64"
       ],
@@ -44,9 +52,9 @@
       }
     },
     "node_modules/@esbuild/android-arm": {
-      "version": "0.25.3",
-      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.25.3.tgz",
-      "integrity": "sha512-PuwVXbnP87Tcff5I9ngV0lmiSu40xw1At6i3GsU77U7cjDDB4s0X2cyFuBiDa1SBk9DnvWwnGvVaGBqoFWPb7A==",
+      "version": "0.25.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.25.5.tgz",
+      "integrity": "sha512-AdJKSPeEHgi7/ZhuIPtcQKr5RQdo6OO2IL87JkianiMYMPbCtot9fxPbrMiBADOWWm3T2si9stAiVsGbTQFkbA==",
       "cpu": [
         "arm"
       ],
@@ -61,9 +69,9 @@
       }
     },
     "node_modules/@esbuild/android-arm64": {
-      "version": "0.25.3",
-      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.25.3.tgz",
-      "integrity": "sha512-XelR6MzjlZuBM4f5z2IQHK6LkK34Cvv6Rj2EntER3lwCBFdg6h2lKbtRjpTTsdEjD/WSe1q8UyPBXP1x3i/wYQ==",
+      "version": "0.25.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.25.5.tgz",
+      "integrity": "sha512-VGzGhj4lJO+TVGV1v8ntCZWJktV7SGCs3Pn1GRWI1SBFtRALoomm8k5E9Pmwg3HOAal2VDc2F9+PM/rEY6oIDg==",
       "cpu": [
         "arm64"
       ],
@@ -78,9 +86,9 @@
       }
     },
     "node_modules/@esbuild/android-x64": {
-      "version": "0.25.3",
-      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.25.3.tgz",
-      "integrity": "sha512-ogtTpYHT/g1GWS/zKM0cc/tIebFjm1F9Aw1boQ2Y0eUQ+J89d0jFY//s9ei9jVIlkYi8AfOjiixcLJSGNSOAdQ==",
+      "version": "0.25.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.25.5.tgz",
+      "integrity": "sha512-D2GyJT1kjvO//drbRT3Hib9XPwQeWd9vZoBJn+bu/lVsOZ13cqNdDeqIF/xQ5/VmWvMduP6AmXvylO/PIc2isw==",
       "cpu": [
         "x64"
       ],
@@ -95,9 +103,9 @@
       }
     },
     "node_modules/@esbuild/darwin-arm64": {
-      "version": "0.25.3",
-      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.25.3.tgz",
-      "integrity": "sha512-eESK5yfPNTqpAmDfFWNsOhmIOaQA59tAcF/EfYvo5/QWQCzXn5iUSOnqt3ra3UdzBv073ykTtmeLJZGt3HhA+w==",
+      "version": "0.25.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.25.5.tgz",
+      "integrity": "sha512-GtaBgammVvdF7aPIgH2jxMDdivezgFu6iKpmT+48+F8Hhg5J/sfnDieg0aeG/jfSvkYQU2/pceFPDKlqZzwnfQ==",
       "cpu": [
         "arm64"
       ],
@@ -112,9 +120,9 @@
       }
     },
     "node_modules/@esbuild/darwin-x64": {
-      "version": "0.25.3",
-      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.25.3.tgz",
-      "integrity": "sha512-Kd8glo7sIZtwOLcPbW0yLpKmBNWMANZhrC1r6K++uDR2zyzb6AeOYtI6udbtabmQpFaxJ8uduXMAo1gs5ozz8A==",
+      "version": "0.25.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.25.5.tgz",
+      "integrity": "sha512-1iT4FVL0dJ76/q1wd7XDsXrSW+oLoquptvh4CLR4kITDtqi2e/xwXwdCVH8hVHU43wgJdsq7Gxuzcs6Iq/7bxQ==",
       "cpu": [
         "x64"
       ],
@@ -129,9 +137,9 @@
       }
     },
     "node_modules/@esbuild/freebsd-arm64": {
-      "version": "0.25.3",
-      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.25.3.tgz",
-      "integrity": "sha512-EJiyS70BYybOBpJth3M0KLOus0n+RRMKTYzhYhFeMwp7e/RaajXvP+BWlmEXNk6uk+KAu46j/kaQzr6au+JcIw==",
+      "version": "0.25.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.25.5.tgz",
+      "integrity": "sha512-nk4tGP3JThz4La38Uy/gzyXtpkPW8zSAmoUhK9xKKXdBCzKODMc2adkB2+8om9BDYugz+uGV7sLmpTYzvmz6Sw==",
       "cpu": [
         "arm64"
       ],
@@ -146,9 +154,9 @@
       }
     },
     "node_modules/@esbuild/freebsd-x64": {
-      "version": "0.25.3",
-      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.25.3.tgz",
-      "integrity": "sha512-Q+wSjaLpGxYf7zC0kL0nDlhsfuFkoN+EXrx2KSB33RhinWzejOd6AvgmP5JbkgXKmjhmpfgKZq24pneodYqE8Q==",
+      "version": "0.25.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.25.5.tgz",
+      "integrity": "sha512-PrikaNjiXdR2laW6OIjlbeuCPrPaAl0IwPIaRv+SMV8CiM8i2LqVUHFC1+8eORgWyY7yhQY+2U2fA55mBzReaw==",
       "cpu": [
         "x64"
       ],
@@ -163,9 +171,9 @@
       }
     },
     "node_modules/@esbuild/linux-arm": {
-      "version": "0.25.3",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.25.3.tgz",
-      "integrity": "sha512-dUOVmAUzuHy2ZOKIHIKHCm58HKzFqd+puLaS424h6I85GlSDRZIA5ycBixb3mFgM0Jdh+ZOSB6KptX30DD8YOQ==",
+      "version": "0.25.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.25.5.tgz",
+      "integrity": "sha512-cPzojwW2okgh7ZlRpcBEtsX7WBuqbLrNXqLU89GxWbNt6uIg78ET82qifUy3W6OVww6ZWobWub5oqZOVtwolfw==",
       "cpu": [
         "arm"
       ],
@@ -180,9 +188,9 @@
       }
     },
     "node_modules/@esbuild/linux-arm64": {
-      "version": "0.25.3",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.25.3.tgz",
-      "integrity": "sha512-xCUgnNYhRD5bb1C1nqrDV1PfkwgbswTTBRbAd8aH5PhYzikdf/ddtsYyMXFfGSsb/6t6QaPSzxtbfAZr9uox4A==",
+      "version": "0.25.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.25.5.tgz",
+      "integrity": "sha512-Z9kfb1v6ZlGbWj8EJk9T6czVEjjq2ntSYLY2cw6pAZl4oKtfgQuS4HOq41M/BcoLPzrUbNd+R4BXFyH//nHxVg==",
       "cpu": [
         "arm64"
       ],
@@ -197,9 +205,9 @@
       }
     },
     "node_modules/@esbuild/linux-ia32": {
-      "version": "0.25.3",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.25.3.tgz",
-      "integrity": "sha512-yplPOpczHOO4jTYKmuYuANI3WhvIPSVANGcNUeMlxH4twz/TeXuzEP41tGKNGWJjuMhotpGabeFYGAOU2ummBw==",
+      "version": "0.25.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.25.5.tgz",
+      "integrity": "sha512-sQ7l00M8bSv36GLV95BVAdhJ2QsIbCuCjh/uYrWiMQSUuV+LpXwIqhgJDcvMTj+VsQmqAHL2yYaasENvJ7CDKA==",
       "cpu": [
         "ia32"
       ],
@@ -214,9 +222,9 @@
       }
     },
     "node_modules/@esbuild/linux-loong64": {
-      "version": "0.25.3",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.25.3.tgz",
-      "integrity": "sha512-P4BLP5/fjyihmXCELRGrLd793q/lBtKMQl8ARGpDxgzgIKJDRJ/u4r1A/HgpBpKpKZelGct2PGI4T+axcedf6g==",
+      "version": "0.25.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.25.5.tgz",
+      "integrity": "sha512-0ur7ae16hDUC4OL5iEnDb0tZHDxYmuQyhKhsPBV8f99f6Z9KQM02g33f93rNH5A30agMS46u2HP6qTdEt6Q1kg==",
       "cpu": [
         "loong64"
       ],
@@ -231,9 +239,9 @@
       }
     },
     "node_modules/@esbuild/linux-mips64el": {
-      "version": "0.25.3",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.25.3.tgz",
-      "integrity": "sha512-eRAOV2ODpu6P5divMEMa26RRqb2yUoYsuQQOuFUexUoQndm4MdpXXDBbUoKIc0iPa4aCO7gIhtnYomkn2x+bag==",
+      "version": "0.25.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.25.5.tgz",
+      "integrity": "sha512-kB/66P1OsHO5zLz0i6X0RxlQ+3cu0mkxS3TKFvkb5lin6uwZ/ttOkP3Z8lfR9mJOBk14ZwZ9182SIIWFGNmqmg==",
       "cpu": [
         "mips64el"
       ],
@@ -248,9 +256,9 @@
       }
     },
     "node_modules/@esbuild/linux-ppc64": {
-      "version": "0.25.3",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.25.3.tgz",
-      "integrity": "sha512-ZC4jV2p7VbzTlnl8nZKLcBkfzIf4Yad1SJM4ZMKYnJqZFD4rTI+pBG65u8ev4jk3/MPwY9DvGn50wi3uhdaghg==",
+      "version": "0.25.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.25.5.tgz",
+      "integrity": "sha512-UZCmJ7r9X2fe2D6jBmkLBMQetXPXIsZjQJCjgwpVDz+YMcS6oFR27alkgGv3Oqkv07bxdvw7fyB71/olceJhkQ==",
       "cpu": [
         "ppc64"
       ],
@@ -265,9 +273,9 @@
       }
     },
     "node_modules/@esbuild/linux-riscv64": {
-      "version": "0.25.3",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.25.3.tgz",
-      "integrity": "sha512-LDDODcFzNtECTrUUbVCs6j9/bDVqy7DDRsuIXJg6so+mFksgwG7ZVnTruYi5V+z3eE5y+BJZw7VvUadkbfg7QA==",
+      "version": "0.25.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.25.5.tgz",
+      "integrity": "sha512-kTxwu4mLyeOlsVIFPfQo+fQJAV9mh24xL+y+Bm6ej067sYANjyEw1dNHmvoqxJUCMnkBdKpvOn0Ahql6+4VyeA==",
       "cpu": [
         "riscv64"
       ],
@@ -282,9 +290,9 @@
       }
     },
     "node_modules/@esbuild/linux-s390x": {
-      "version": "0.25.3",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.25.3.tgz",
-      "integrity": "sha512-s+w/NOY2k0yC2p9SLen+ymflgcpRkvwwa02fqmAwhBRI3SC12uiS10edHHXlVWwfAagYSY5UpmT/zISXPMW3tQ==",
+      "version": "0.25.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.25.5.tgz",
+      "integrity": "sha512-K2dSKTKfmdh78uJ3NcWFiqyRrimfdinS5ErLSn3vluHNeHVnBAFWC8a4X5N+7FgVE1EjXS1QDZbpqZBjfrqMTQ==",
       "cpu": [
         "s390x"
       ],
@@ -299,9 +307,9 @@
       }
     },
     "node_modules/@esbuild/linux-x64": {
-      "version": "0.25.3",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.25.3.tgz",
-      "integrity": "sha512-nQHDz4pXjSDC6UfOE1Fw9Q8d6GCAd9KdvMZpfVGWSJztYCarRgSDfOVBY5xwhQXseiyxapkiSJi/5/ja8mRFFA==",
+      "version": "0.25.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.25.5.tgz",
+      "integrity": "sha512-uhj8N2obKTE6pSZ+aMUbqq+1nXxNjZIIjCjGLfsWvVpy7gKCOL6rsY1MhRh9zLtUtAI7vpgLMK6DxjO8Qm9lJw==",
       "cpu": [
         "x64"
       ],
@@ -316,9 +324,9 @@
       }
     },
     "node_modules/@esbuild/netbsd-arm64": {
-      "version": "0.25.3",
-      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.25.3.tgz",
-      "integrity": "sha512-1QaLtOWq0mzK6tzzp0jRN3eccmN3hezey7mhLnzC6oNlJoUJz4nym5ZD7mDnS/LZQgkrhEbEiTn515lPeLpgWA==",
+      "version": "0.25.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.25.5.tgz",
+      "integrity": "sha512-pwHtMP9viAy1oHPvgxtOv+OkduK5ugofNTVDilIzBLpoWAM16r7b/mxBvfpuQDpRQFMfuVr5aLcn4yveGvBZvw==",
       "cpu": [
         "arm64"
       ],
@@ -333,9 +341,9 @@
       }
     },
     "node_modules/@esbuild/netbsd-x64": {
-      "version": "0.25.3",
-      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.25.3.tgz",
-      "integrity": "sha512-i5Hm68HXHdgv8wkrt+10Bc50zM0/eonPb/a/OFVfB6Qvpiirco5gBA5bz7S2SHuU+Y4LWn/zehzNX14Sp4r27g==",
+      "version": "0.25.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.25.5.tgz",
+      "integrity": "sha512-WOb5fKrvVTRMfWFNCroYWWklbnXH0Q5rZppjq0vQIdlsQKuw6mdSihwSo4RV/YdQ5UCKKvBy7/0ZZYLBZKIbwQ==",
       "cpu": [
         "x64"
       ],
@@ -350,9 +358,9 @@
       }
     },
     "node_modules/@esbuild/openbsd-arm64": {
-      "version": "0.25.3",
-      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.25.3.tgz",
-      "integrity": "sha512-zGAVApJEYTbOC6H/3QBr2mq3upG/LBEXr85/pTtKiv2IXcgKV0RT0QA/hSXZqSvLEpXeIxah7LczB4lkiYhTAQ==",
+      "version": "0.25.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.25.5.tgz",
+      "integrity": "sha512-7A208+uQKgTxHd0G0uqZO8UjK2R0DDb4fDmERtARjSHWxqMTye4Erz4zZafx7Di9Cv+lNHYuncAkiGFySoD+Mw==",
       "cpu": [
         "arm64"
       ],
@@ -367,9 +375,9 @@
       }
     },
     "node_modules/@esbuild/openbsd-x64": {
-      "version": "0.25.3",
-      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.25.3.tgz",
-      "integrity": "sha512-fpqctI45NnCIDKBH5AXQBsD0NDPbEFczK98hk/aa6HJxbl+UtLkJV2+Bvy5hLSLk3LHmqt0NTkKNso1A9y1a4w==",
+      "version": "0.25.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.25.5.tgz",
+      "integrity": "sha512-G4hE405ErTWraiZ8UiSoesH8DaCsMm0Cay4fsFWOOUcz8b8rC6uCvnagr+gnioEjWn0wC+o1/TAHt+It+MpIMg==",
       "cpu": [
         "x64"
       ],
@@ -384,9 +392,9 @@
       }
     },
     "node_modules/@esbuild/sunos-x64": {
-      "version": "0.25.3",
-      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.25.3.tgz",
-      "integrity": "sha512-ROJhm7d8bk9dMCUZjkS8fgzsPAZEjtRJqCAmVgB0gMrvG7hfmPmz9k1rwO4jSiblFjYmNvbECL9uhaPzONMfgA==",
+      "version": "0.25.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.25.5.tgz",
+      "integrity": "sha512-l+azKShMy7FxzY0Rj4RCt5VD/q8mG/e+mDivgspo+yL8zW7qEwctQ6YqKX34DTEleFAvCIUviCFX1SDZRSyMQA==",
       "cpu": [
         "x64"
       ],
@@ -401,9 +409,9 @@
       }
     },
     "node_modules/@esbuild/win32-arm64": {
-      "version": "0.25.3",
-      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.25.3.tgz",
-      "integrity": "sha512-YWcow8peiHpNBiIXHwaswPnAXLsLVygFwCB3A7Bh5jRkIBFWHGmNQ48AlX4xDvQNoMZlPYzjVOQDYEzWCqufMQ==",
+      "version": "0.25.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.25.5.tgz",
+      "integrity": "sha512-O2S7SNZzdcFG7eFKgvwUEZ2VG9D/sn/eIiz8XRZ1Q/DO5a3s76Xv0mdBzVM5j5R639lXQmPmSo0iRpHqUUrsxw==",
       "cpu": [
         "arm64"
       ],
@@ -418,9 +426,9 @@
       }
     },
     "node_modules/@esbuild/win32-ia32": {
-      "version": "0.25.3",
-      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.25.3.tgz",
-      "integrity": "sha512-qspTZOIGoXVS4DpNqUYUs9UxVb04khS1Degaw/MnfMe7goQ3lTfQ13Vw4qY/Nj0979BGvMRpAYbs/BAxEvU8ew==",
+      "version": "0.25.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.25.5.tgz",
+      "integrity": "sha512-onOJ02pqs9h1iMJ1PQphR+VZv8qBMQ77Klcsqv9CNW2w6yLqoURLcgERAIurY6QE63bbLuqgP9ATqajFLK5AMQ==",
       "cpu": [
         "ia32"
       ],
@@ -435,9 +443,9 @@
       }
     },
     "node_modules/@esbuild/win32-x64": {
-      "version": "0.25.3",
-      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.25.3.tgz",
-      "integrity": "sha512-ICgUR+kPimx0vvRzf+N/7L7tVSQeE3BYY+NhHRHXS1kBuPO7z2+7ea2HbhDyZdTephgvNvKrlDDKUexuCVBVvg==",
+      "version": "0.25.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.25.5.tgz",
+      "integrity": "sha512-TXv6YnJ8ZMVdX+SXWVBo/0p8LTcrUYngpWjvm91TMjjBQii7Oz11Lw5lbDV5Y0TzuhSJHwiH4hEtC1I42mMS0g==",
       "cpu": [
         "x64"
       ],
@@ -451,6 +459,13 @@
         "node": ">=18"
       }
     },
+    "node_modules/@japont/unicode-range": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@japont/unicode-range/-/unicode-range-1.0.0.tgz",
+      "integrity": "sha512-BckHvA2XdjRBVAWe2uceNuRf78lBeI28kyWEbfr/Q2pE17POkwuZ6WWY/UMv8FL9iBxhW4xfDoNLM9UVZaTeUQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@jridgewell/sourcemap-codec": {
       "version": "1.5.0",
       "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.0.tgz",
@@ -459,9 +474,9 @@
       "license": "MIT"
     },
     "node_modules/@rollup/rollup-android-arm-eabi": {
-      "version": "4.40.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.40.0.tgz",
-      "integrity": "sha512-+Fbls/diZ0RDerhE8kyC6hjADCXA1K4yVNlH0EYfd2XjyH0UGgzaQ8MlT0pCXAThfxv3QUAczHaL+qSv1E4/Cg==",
+      "version": "4.41.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.41.1.tgz",
+      "integrity": "sha512-NELNvyEWZ6R9QMkiytB4/L4zSEaBC03KIXEghptLGLZWJ6VPrL63ooZQCOnlx36aQPGhzuOMwDerC1Eb2VmrLw==",
       "cpu": [
         "arm"
       ],
@@ -473,9 +488,9 @@
       ]
     },
     "node_modules/@rollup/rollup-android-arm64": {
-      "version": "4.40.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.40.0.tgz",
-      "integrity": "sha512-PPA6aEEsTPRz+/4xxAmaoWDqh67N7wFbgFUJGMnanCFs0TV99M0M8QhhaSCks+n6EbQoFvLQgYOGXxlMGQe/6w==",
+      "version": "4.41.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.41.1.tgz",
+      "integrity": "sha512-DXdQe1BJ6TK47ukAoZLehRHhfKnKg9BjnQYUu9gzhI8Mwa1d2fzxA1aw2JixHVl403bwp1+/o/NhhHtxWJBgEA==",
       "cpu": [
         "arm64"
       ],
@@ -487,9 +502,9 @@
       ]
     },
     "node_modules/@rollup/rollup-darwin-arm64": {
-      "version": "4.40.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.40.0.tgz",
-      "integrity": "sha512-GwYOcOakYHdfnjjKwqpTGgn5a6cUX7+Ra2HeNj/GdXvO2VJOOXCiYYlRFU4CubFM67EhbmzLOmACKEfvp3J1kQ==",
+      "version": "4.41.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.41.1.tgz",
+      "integrity": "sha512-5afxvwszzdulsU2w8JKWwY8/sJOLPzf0e1bFuvcW5h9zsEg+RQAojdW0ux2zyYAz7R8HvvzKCjLNJhVq965U7w==",
       "cpu": [
         "arm64"
       ],
@@ -501,9 +516,9 @@
       ]
     },
     "node_modules/@rollup/rollup-darwin-x64": {
-      "version": "4.40.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.40.0.tgz",
-      "integrity": "sha512-CoLEGJ+2eheqD9KBSxmma6ld01czS52Iw0e2qMZNpPDlf7Z9mj8xmMemxEucinev4LgHalDPczMyxzbq+Q+EtA==",
+      "version": "4.41.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.41.1.tgz",
+      "integrity": "sha512-egpJACny8QOdHNNMZKf8xY0Is6gIMz+tuqXlusxquWu3F833DcMwmGM7WlvCO9sB3OsPjdC4U0wHw5FabzCGZg==",
       "cpu": [
         "x64"
       ],
@@ -515,9 +530,9 @@
       ]
     },
     "node_modules/@rollup/rollup-freebsd-arm64": {
-      "version": "4.40.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.40.0.tgz",
-      "integrity": "sha512-r7yGiS4HN/kibvESzmrOB/PxKMhPTlz+FcGvoUIKYoTyGd5toHp48g1uZy1o1xQvybwwpqpe010JrcGG2s5nkg==",
+      "version": "4.41.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.41.1.tgz",
+      "integrity": "sha512-DBVMZH5vbjgRk3r0OzgjS38z+atlupJ7xfKIDJdZZL6sM6wjfDNo64aowcLPKIx7LMQi8vybB56uh1Ftck/Atg==",
       "cpu": [
         "arm64"
       ],
@@ -529,9 +544,9 @@
       ]
     },
     "node_modules/@rollup/rollup-freebsd-x64": {
-      "version": "4.40.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.40.0.tgz",
-      "integrity": "sha512-mVDxzlf0oLzV3oZOr0SMJ0lSDd3xC4CmnWJ8Val8isp9jRGl5Dq//LLDSPFrasS7pSm6m5xAcKaw3sHXhBjoRw==",
+      "version": "4.41.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.41.1.tgz",
+      "integrity": "sha512-3FkydeohozEskBxNWEIbPfOE0aqQgB6ttTkJ159uWOFn42VLyfAiyD9UK5mhu+ItWzft60DycIN1Xdgiy8o/SA==",
       "cpu": [
         "x64"
       ],
@@ -543,9 +558,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-arm-gnueabihf": {
-      "version": "4.40.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.40.0.tgz",
-      "integrity": "sha512-y/qUMOpJxBMy8xCXD++jeu8t7kzjlOCkoxxajL58G62PJGBZVl/Gwpm7JK9+YvlB701rcQTzjUZ1JgUoPTnoQA==",
+      "version": "4.41.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.41.1.tgz",
+      "integrity": "sha512-wC53ZNDgt0pqx5xCAgNunkTzFE8GTgdZ9EwYGVcg+jEjJdZGtq9xPjDnFgfFozQI/Xm1mh+D9YlYtl+ueswNEg==",
       "cpu": [
         "arm"
       ],
@@ -557,9 +572,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-arm-musleabihf": {
-      "version": "4.40.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.40.0.tgz",
-      "integrity": "sha512-GoCsPibtVdJFPv/BOIvBKO/XmwZLwaNWdyD8TKlXuqp0veo2sHE+A/vpMQ5iSArRUz/uaoj4h5S6Pn0+PdhRjg==",
+      "version": "4.41.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.41.1.tgz",
+      "integrity": "sha512-jwKCca1gbZkZLhLRtsrka5N8sFAaxrGz/7wRJ8Wwvq3jug7toO21vWlViihG85ei7uJTpzbXZRcORotE+xyrLA==",
       "cpu": [
         "arm"
       ],
@@ -571,9 +586,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-arm64-gnu": {
-      "version": "4.40.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.40.0.tgz",
-      "integrity": "sha512-L5ZLphTjjAD9leJzSLI7rr8fNqJMlGDKlazW2tX4IUF9P7R5TMQPElpH82Q7eNIDQnQlAyiNVfRPfP2vM5Avvg==",
+      "version": "4.41.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.41.1.tgz",
+      "integrity": "sha512-g0UBcNknsmmNQ8V2d/zD2P7WWfJKU0F1nu0k5pW4rvdb+BIqMm8ToluW/eeRmxCared5dD76lS04uL4UaNgpNA==",
       "cpu": [
         "arm64"
       ],
@@ -585,9 +600,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-arm64-musl": {
-      "version": "4.40.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.40.0.tgz",
-      "integrity": "sha512-ATZvCRGCDtv1Y4gpDIXsS+wfFeFuLwVxyUBSLawjgXK2tRE6fnsQEkE4csQQYWlBlsFztRzCnBvWVfcae/1qxQ==",
+      "version": "4.41.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.41.1.tgz",
+      "integrity": "sha512-XZpeGB5TKEZWzIrj7sXr+BEaSgo/ma/kCgrZgL0oo5qdB1JlTzIYQKel/RmhT6vMAvOdM2teYlAaOGJpJ9lahg==",
       "cpu": [
         "arm64"
       ],
@@ -599,9 +614,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-loongarch64-gnu": {
-      "version": "4.40.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loongarch64-gnu/-/rollup-linux-loongarch64-gnu-4.40.0.tgz",
-      "integrity": "sha512-wG9e2XtIhd++QugU5MD9i7OnpaVb08ji3P1y/hNbxrQ3sYEelKJOq1UJ5dXczeo6Hj2rfDEL5GdtkMSVLa/AOg==",
+      "version": "4.41.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loongarch64-gnu/-/rollup-linux-loongarch64-gnu-4.41.1.tgz",
+      "integrity": "sha512-bkCfDJ4qzWfFRCNt5RVV4DOw6KEgFTUZi2r2RuYhGWC8WhCA8lCAJhDeAmrM/fdiAH54m0mA0Vk2FGRPyzI+tw==",
       "cpu": [
         "loong64"
       ],
@@ -613,9 +628,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-powerpc64le-gnu": {
-      "version": "4.40.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-powerpc64le-gnu/-/rollup-linux-powerpc64le-gnu-4.40.0.tgz",
-      "integrity": "sha512-vgXfWmj0f3jAUvC7TZSU/m/cOE558ILWDzS7jBhiCAFpY2WEBn5jqgbqvmzlMjtp8KlLcBlXVD2mkTSEQE6Ixw==",
+      "version": "4.41.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-powerpc64le-gnu/-/rollup-linux-powerpc64le-gnu-4.41.1.tgz",
+      "integrity": "sha512-3mr3Xm+gvMX+/8EKogIZSIEF0WUu0HL9di+YWlJpO8CQBnoLAEL/roTCxuLncEdgcfJcvA4UMOf+2dnjl4Ut1A==",
       "cpu": [
         "ppc64"
       ],
@@ -627,9 +642,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-riscv64-gnu": {
-      "version": "4.40.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.40.0.tgz",
-      "integrity": "sha512-uJkYTugqtPZBS3Z136arevt/FsKTF/J9dEMTX/cwR7lsAW4bShzI2R0pJVw+hcBTWF4dxVckYh72Hk3/hWNKvA==",
+      "version": "4.41.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.41.1.tgz",
+      "integrity": "sha512-3rwCIh6MQ1LGrvKJitQjZFuQnT2wxfU+ivhNBzmxXTXPllewOF7JR1s2vMX/tWtUYFgphygxjqMl76q4aMotGw==",
       "cpu": [
         "riscv64"
       ],
@@ -641,9 +656,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-riscv64-musl": {
-      "version": "4.40.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-musl/-/rollup-linux-riscv64-musl-4.40.0.tgz",
-      "integrity": "sha512-rKmSj6EXQRnhSkE22+WvrqOqRtk733x3p5sWpZilhmjnkHkpeCgWsFFo0dGnUGeA+OZjRl3+VYq+HyCOEuwcxQ==",
+      "version": "4.41.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-musl/-/rollup-linux-riscv64-musl-4.41.1.tgz",
+      "integrity": "sha512-LdIUOb3gvfmpkgFZuccNa2uYiqtgZAz3PTzjuM5bH3nvuy9ty6RGc/Q0+HDFrHrizJGVpjnTZ1yS5TNNjFlklw==",
       "cpu": [
         "riscv64"
       ],
@@ -655,9 +670,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-s390x-gnu": {
-      "version": "4.40.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.40.0.tgz",
-      "integrity": "sha512-SpnYlAfKPOoVsQqmTFJ0usx0z84bzGOS9anAC0AZ3rdSo3snecihbhFTlJZ8XMwzqAcodjFU4+/SM311dqE5Sw==",
+      "version": "4.41.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.41.1.tgz",
+      "integrity": "sha512-oIE6M8WC9ma6xYqjvPhzZYk6NbobIURvP/lEbh7FWplcMO6gn7MM2yHKA1eC/GvYwzNKK/1LYgqzdkZ8YFxR8g==",
       "cpu": [
         "s390x"
       ],
@@ -669,9 +684,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-x64-gnu": {
-      "version": "4.40.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.40.0.tgz",
-      "integrity": "sha512-RcDGMtqF9EFN8i2RYN2W+64CdHruJ5rPqrlYw+cgM3uOVPSsnAQps7cpjXe9be/yDp8UC7VLoCoKC8J3Kn2FkQ==",
+      "version": "4.41.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.41.1.tgz",
+      "integrity": "sha512-cWBOvayNvA+SyeQMp79BHPK8ws6sHSsYnK5zDcsC3Hsxr1dgTABKjMnMslPq1DvZIp6uO7kIWhiGwaTdR4Og9A==",
       "cpu": [
         "x64"
       ],
@@ -683,9 +698,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-x64-musl": {
-      "version": "4.40.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.40.0.tgz",
-      "integrity": "sha512-HZvjpiUmSNx5zFgwtQAV1GaGazT2RWvqeDi0hV+AtC8unqqDSsaFjPxfsO6qPtKRRg25SisACWnJ37Yio8ttaw==",
+      "version": "4.41.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.41.1.tgz",
+      "integrity": "sha512-y5CbN44M+pUCdGDlZFzGGBSKCA4A/J2ZH4edTYSSxFg7ce1Xt3GtydbVKWLlzL+INfFIZAEg1ZV6hh9+QQf9YQ==",
       "cpu": [
         "x64"
       ],
@@ -697,9 +712,9 @@
       ]
     },
     "node_modules/@rollup/rollup-win32-arm64-msvc": {
-      "version": "4.40.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.40.0.tgz",
-      "integrity": "sha512-UtZQQI5k/b8d7d3i9AZmA/t+Q4tk3hOC0tMOMSq2GlMYOfxbesxG4mJSeDp0EHs30N9bsfwUvs3zF4v/RzOeTQ==",
+      "version": "4.41.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.41.1.tgz",
+      "integrity": "sha512-lZkCxIrjlJlMt1dLO/FbpZbzt6J/A8p4DnqzSa4PWqPEUUUnzXLeki/iyPLfV0BmHItlYgHUqJe+3KiyydmiNQ==",
       "cpu": [
         "arm64"
       ],
@@ -711,9 +726,9 @@
       ]
     },
     "node_modules/@rollup/rollup-win32-ia32-msvc": {
-      "version": "4.40.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.40.0.tgz",
-      "integrity": "sha512-+m03kvI2f5syIqHXCZLPVYplP8pQch9JHyXKZ3AGMKlg8dCyr2PKHjwRLiW53LTrN/Nc3EqHOKxUxzoSPdKddA==",
+      "version": "4.41.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.41.1.tgz",
+      "integrity": "sha512-+psFT9+pIh2iuGsxFYYa/LhS5MFKmuivRsx9iPJWNSGbh2XVEjk90fmpUEjCnILPEPJnikAU6SFDiEUyOv90Pg==",
       "cpu": [
         "ia32"
       ],
@@ -725,9 +740,9 @@
       ]
     },
     "node_modules/@rollup/rollup-win32-x64-msvc": {
-      "version": "4.40.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.40.0.tgz",
-      "integrity": "sha512-lpPE1cLfP5oPzVjKMx10pgBmKELQnFJXHgvtHCtuJWOv8MxqdEIMNtgHgBFf7Ea2/7EuVwa9fodWUfXAlXZLZQ==",
+      "version": "4.41.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.41.1.tgz",
+      "integrity": "sha512-Wq2zpapRYLfi4aKxf2Xff0tN+7slj2d4R87WEzqw7ZLsVvO5zwYCIuEGSZYiK41+GlwUo1HiR+GdkLEJnCKTCw==",
       "cpu": [
         "x64"
       ],
@@ -758,14 +773,14 @@
       "license": "MIT"
     },
     "node_modules/@vitest/expect": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-3.1.2.tgz",
-      "integrity": "sha512-O8hJgr+zREopCAqWl3uCVaOdqJwZ9qaDwUP7vy3Xigad0phZe9APxKhPcDNqYYi0rX5oMvwJMSCAXY2afqeTSA==",
+      "version": "3.1.4",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-3.1.4.tgz",
+      "integrity": "sha512-xkD/ljeliyaClDYqHPNCiJ0plY5YIcM0OlRiZizLhlPmpXWpxnGMyTZXOHFhFeG7w9P5PBeL4IdtJ/HeQwTbQA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@vitest/spy": "3.1.2",
-        "@vitest/utils": "3.1.2",
+        "@vitest/spy": "3.1.4",
+        "@vitest/utils": "3.1.4",
         "chai": "^5.2.0",
         "tinyrainbow": "^2.0.0"
       },
@@ -774,13 +789,13 @@
       }
     },
     "node_modules/@vitest/mocker": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-3.1.2.tgz",
-      "integrity": "sha512-kOtd6K2lc7SQ0mBqYv/wdGedlqPdM/B38paPY+OwJ1XiNi44w3Fpog82UfOibmHaV9Wod18A09I9SCKLyDMqgw==",
+      "version": "3.1.4",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-3.1.4.tgz",
+      "integrity": "sha512-8IJ3CvwtSw/EFXqWFL8aCMu+YyYXG2WUSrQbViOZkWTKTVicVwZ/YiEZDSqD00kX+v/+W+OnxhNWoeVKorHygA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@vitest/spy": "3.1.2",
+        "@vitest/spy": "3.1.4",
         "estree-walker": "^3.0.3",
         "magic-string": "^0.30.17"
       },
@@ -801,9 +816,9 @@
       }
     },
     "node_modules/@vitest/pretty-format": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-3.1.2.tgz",
-      "integrity": "sha512-R0xAiHuWeDjTSB3kQ3OQpT8Rx3yhdOAIm/JM4axXxnG7Q/fS8XUwggv/A4xzbQA+drYRjzkMnpYnOGAc4oeq8w==",
+      "version": "3.1.4",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-3.1.4.tgz",
+      "integrity": "sha512-cqv9H9GvAEoTaoq+cYqUTCGscUjKqlJZC7PRwY5FMySVj5J+xOm1KQcCiYHJOEzOKRUhLH4R2pTwvFlWCEScsg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -814,13 +829,13 @@
       }
     },
     "node_modules/@vitest/runner": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-3.1.2.tgz",
-      "integrity": "sha512-bhLib9l4xb4sUMPXnThbnhX2Yi8OutBMA8Yahxa7yavQsFDtwY/jrUZwpKp2XH9DhRFJIeytlyGpXCqZ65nR+g==",
+      "version": "3.1.4",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-3.1.4.tgz",
+      "integrity": "sha512-djTeF1/vt985I/wpKVFBMWUlk/I7mb5hmD5oP8K9ACRmVXgKTae3TUOtXAEBfslNKPzUQvnKhNd34nnRSYgLNQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@vitest/utils": "3.1.2",
+        "@vitest/utils": "3.1.4",
         "pathe": "^2.0.3"
       },
       "funding": {
@@ -828,13 +843,13 @@
       }
     },
     "node_modules/@vitest/snapshot": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-3.1.2.tgz",
-      "integrity": "sha512-Q1qkpazSF/p4ApZg1vfZSQ5Yw6OCQxVMVrLjslbLFA1hMDrT2uxtqMaw8Tc/jy5DLka1sNs1Y7rBcftMiaSH/Q==",
+      "version": "3.1.4",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-3.1.4.tgz",
+      "integrity": "sha512-JPHf68DvuO7vilmvwdPr9TS0SuuIzHvxeaCkxYcCD4jTk67XwL45ZhEHFKIuCm8CYstgI6LZ4XbwD6ANrwMpFg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@vitest/pretty-format": "3.1.2",
+        "@vitest/pretty-format": "3.1.4",
         "magic-string": "^0.30.17",
         "pathe": "^2.0.3"
       },
@@ -843,9 +858,9 @@
       }
     },
     "node_modules/@vitest/spy": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-3.1.2.tgz",
-      "integrity": "sha512-OEc5fSXMws6sHVe4kOFyDSj/+4MSwst0ib4un0DlcYgQvRuYQ0+M2HyqGaauUMnjq87tmUaMNDxKQx7wNfVqPA==",
+      "version": "3.1.4",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-3.1.4.tgz",
+      "integrity": "sha512-Xg1bXhu+vtPXIodYN369M86K8shGLouNjoVI78g8iAq2rFoHFdajNvJJ5A/9bPMFcfQqdaCpOgWKEoMQg/s0Yg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -856,13 +871,13 @@
       }
     },
     "node_modules/@vitest/utils": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-3.1.2.tgz",
-      "integrity": "sha512-5GGd0ytZ7BH3H6JTj9Kw7Prn1Nbg0wZVrIvou+UWxm54d+WoXXgAgjFJ8wn3LdagWLFSEfpPeyYrByZaGEZHLg==",
+      "version": "3.1.4",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-3.1.4.tgz",
+      "integrity": "sha512-yriMuO1cfFhmiGc8ataN51+9ooHRuURdfAZfwFd3usWynjzpLslZdYnRegTv32qdgtJTsj15FoeZe2g15fY1gg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@vitest/pretty-format": "3.1.2",
+        "@vitest/pretty-format": "3.1.4",
         "loupe": "^3.1.3",
         "tinyrainbow": "^2.0.0"
       },
@@ -886,8 +901,6 @@
       "integrity": "sha512-cl669nCJTZBsL97OF4kUQm5g5hC2uihk0NxY3WENAC0TYdILVkAyHymAntgxGkl7K+t0cXIrH5siy5S4XkFycA==",
       "dev": true,
       "license": "MIT",
-      "optional": true,
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -1044,6 +1057,13 @@
       "engines": {
         "node": ">= 16"
       }
+    },
+    "node_modules/colorjs.io": {
+      "version": "0.5.2",
+      "resolved": "https://registry.npmjs.org/colorjs.io/-/colorjs.io-0.5.2.tgz",
+      "integrity": "sha512-twmVoizEW7ylZSN32OgKdXRmo1qg+wT5/6C3xu5b9QsWzSFAhHLn2xd8ro0diCsKfCj1RdaTP/nrcW+vAoQPIw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/combined-stream": {
       "version": "1.0.8",
@@ -1273,9 +1293,9 @@
       }
     },
     "node_modules/esbuild": {
-      "version": "0.25.3",
-      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.25.3.tgz",
-      "integrity": "sha512-qKA6Pvai73+M2FtftpNKRxJ78GIjmFXFxd/1DVBqGo/qNhLSfv+G12n9pNoWdytJC8U00TrViOwpjT0zgqQS8Q==",
+      "version": "0.25.5",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.25.5.tgz",
+      "integrity": "sha512-P8OtKZRv/5J5hhz0cUAdu/cLuPIKXpQl1R9pZtvmHWQvrAUVd0UNIPT4IB4W3rNOqVO0rlqHmCIbSwxh/c9yUQ==",
       "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
@@ -1286,31 +1306,31 @@
         "node": ">=18"
       },
       "optionalDependencies": {
-        "@esbuild/aix-ppc64": "0.25.3",
-        "@esbuild/android-arm": "0.25.3",
-        "@esbuild/android-arm64": "0.25.3",
-        "@esbuild/android-x64": "0.25.3",
-        "@esbuild/darwin-arm64": "0.25.3",
-        "@esbuild/darwin-x64": "0.25.3",
-        "@esbuild/freebsd-arm64": "0.25.3",
-        "@esbuild/freebsd-x64": "0.25.3",
-        "@esbuild/linux-arm": "0.25.3",
-        "@esbuild/linux-arm64": "0.25.3",
-        "@esbuild/linux-ia32": "0.25.3",
-        "@esbuild/linux-loong64": "0.25.3",
-        "@esbuild/linux-mips64el": "0.25.3",
-        "@esbuild/linux-ppc64": "0.25.3",
-        "@esbuild/linux-riscv64": "0.25.3",
-        "@esbuild/linux-s390x": "0.25.3",
-        "@esbuild/linux-x64": "0.25.3",
-        "@esbuild/netbsd-arm64": "0.25.3",
-        "@esbuild/netbsd-x64": "0.25.3",
-        "@esbuild/openbsd-arm64": "0.25.3",
-        "@esbuild/openbsd-x64": "0.25.3",
-        "@esbuild/sunos-x64": "0.25.3",
-        "@esbuild/win32-arm64": "0.25.3",
-        "@esbuild/win32-ia32": "0.25.3",
-        "@esbuild/win32-x64": "0.25.3"
+        "@esbuild/aix-ppc64": "0.25.5",
+        "@esbuild/android-arm": "0.25.5",
+        "@esbuild/android-arm64": "0.25.5",
+        "@esbuild/android-x64": "0.25.5",
+        "@esbuild/darwin-arm64": "0.25.5",
+        "@esbuild/darwin-x64": "0.25.5",
+        "@esbuild/freebsd-arm64": "0.25.5",
+        "@esbuild/freebsd-x64": "0.25.5",
+        "@esbuild/linux-arm": "0.25.5",
+        "@esbuild/linux-arm64": "0.25.5",
+        "@esbuild/linux-ia32": "0.25.5",
+        "@esbuild/linux-loong64": "0.25.5",
+        "@esbuild/linux-mips64el": "0.25.5",
+        "@esbuild/linux-ppc64": "0.25.5",
+        "@esbuild/linux-riscv64": "0.25.5",
+        "@esbuild/linux-s390x": "0.25.5",
+        "@esbuild/linux-x64": "0.25.5",
+        "@esbuild/netbsd-arm64": "0.25.5",
+        "@esbuild/netbsd-x64": "0.25.5",
+        "@esbuild/openbsd-arm64": "0.25.5",
+        "@esbuild/openbsd-x64": "0.25.5",
+        "@esbuild/sunos-x64": "0.25.5",
+        "@esbuild/win32-arm64": "0.25.5",
+        "@esbuild/win32-ia32": "0.25.5",
+        "@esbuild/win32-x64": "0.25.5"
       }
     },
     "node_modules/escodegen": {
@@ -1319,8 +1339,6 @@
       "integrity": "sha512-2NlIDTwUWJN0mRPQOdtQBzbUHvdGY2P1VXSyU83Q3xKxM7WHX2Ql8dKq782Q9TgQUNOLEzEYu9bzLNj1q88I5w==",
       "dev": true,
       "license": "BSD-2-Clause",
-      "optional": true,
-      "peer": true,
       "dependencies": {
         "esprima": "^4.0.1",
         "estraverse": "^5.2.0",
@@ -1343,8 +1361,6 @@
       "integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==",
       "dev": true,
       "license": "BSD-2-Clause",
-      "optional": true,
-      "peer": true,
       "bin": {
         "esparse": "bin/esparse.js",
         "esvalidate": "bin/esvalidate.js"
@@ -1359,8 +1375,6 @@
       "integrity": "sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==",
       "dev": true,
       "license": "BSD-2-Clause",
-      "optional": true,
-      "peer": true,
       "engines": {
         "node": ">=4.0"
       }
@@ -1381,8 +1395,6 @@
       "integrity": "sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==",
       "dev": true,
       "license": "BSD-2-Clause",
-      "optional": true,
-      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -1398,9 +1410,9 @@
       }
     },
     "node_modules/fdir": {
-      "version": "6.4.4",
-      "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.4.4.tgz",
-      "integrity": "sha512-1NZP+GK4GfuAv3PqKvxQRDMjdSRZjnkq7KfhlNrCNNlZ0ygQFpebfrnfnq/W7fpUnAv9aGWmY1zKx7FYL3gwhg==",
+      "version": "6.4.5",
+      "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.4.5.tgz",
+      "integrity": "sha512-4BG7puHpVsIYxZUbiUE3RqGloLaSSwzYie5jvasC4LWuBWzZawynvYouhjbQKw2JuIGYdm0DzIxl8iVidKlUEw==",
       "dev": true,
       "license": "MIT",
       "peerDependencies": {
@@ -1411,6 +1423,13 @@
           "optional": true
         }
       }
+    },
+    "node_modules/file-saver": {
+      "version": "1.3.8",
+      "resolved": "https://registry.npmjs.org/file-saver/-/file-saver-1.3.8.tgz",
+      "integrity": "sha512-spKHSBQIxxS81N/O21WmuXA2F6wppUCsutpzenOeZzOCCJ5gEfcbqJP983IrpLXzYmXnMUa6J03SubcNPdKrlg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/form-data": {
       "version": "4.0.2",
@@ -1499,6 +1518,13 @@
       "engines": {
         "node": ">= 0.4"
       }
+    },
+    "node_modules/gifenc": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/gifenc/-/gifenc-1.0.3.tgz",
+      "integrity": "sha512-xdr6AdrfGBcfzncONUOlXMBuc5wJDtOueE3c5rdG0oNgtINLD+f2iFZltrBRZYzACRbKr+mSVU/x98zv2u3jmw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/gopd": {
       "version": "1.2.0",
@@ -1611,6 +1637,26 @@
         "node": ">= 6"
       }
     },
+    "node_modules/i18next": {
+      "version": "19.9.2",
+      "resolved": "https://registry.npmjs.org/i18next/-/i18next-19.9.2.tgz",
+      "integrity": "sha512-0i6cuo6ER6usEOtKajUUDj92zlG+KArFia0857xxiEHAQcUwh/RtOQocui1LPJwunSYT574Pk64aNva1kwtxZg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.12.0"
+      }
+    },
+    "node_modules/i18next-browser-languagedetector": {
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/i18next-browser-languagedetector/-/i18next-browser-languagedetector-4.3.1.tgz",
+      "integrity": "sha512-KIToAzf8zwWvacgnRwJp63ase26o24AuNUlfNVJ5YZAFmdGhsJpmFClxXPuk9rv1FMI4lnc8zLSqgZPEZMrW4g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.5.5"
+      }
+    },
     "node_modules/iconv-lite": {
       "version": "0.6.3",
       "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
@@ -1683,6 +1729,13 @@
           "optional": true
         }
       }
+    },
+    "node_modules/libtess": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/libtess/-/libtess-1.2.2.tgz",
+      "integrity": "sha512-Nps8HPeVVcsmJxUvFLKVJcCgcz+1ajPTXDVAVPs6+giOQP4AHV31uZFFkh+CKow/bkB7GbZWKmwmit7myaqDSw==",
+      "dev": true,
+      "license": "SGI-B-2.0"
     },
     "node_modules/loupe": {
       "version": "3.1.3",
@@ -1775,6 +1828,57 @@
       "optional": true,
       "peer": true
     },
+    "node_modules/omggif": {
+      "version": "1.0.10",
+      "resolved": "https://registry.npmjs.org/omggif/-/omggif-1.0.10.tgz",
+      "integrity": "sha512-LMJTtvgc/nugXj0Vcrrs68Mn2D1r0zf630VNtqtpI1FEO7e+O9FP4gqs9AcnBaSEeoHIPm28u6qgPR0oyEpGSw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/p5": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/p5/-/p5-2.0.2.tgz",
+      "integrity": "sha512-whgJRTVEtpYqYlM0t3Si/lkYSz0S2/jMReaodFKgWuwHrQmMmDT4ve7bcwqw2R42NWW6jq0WJFVnwV8OjADlEA==",
+      "dev": true,
+      "license": "LGPL-2.1",
+      "dependencies": {
+        "@davepagurek/bezier-path": "^0.0.2",
+        "@japont/unicode-range": "^1.0.0",
+        "acorn": "^8.12.1",
+        "acorn-walk": "^8.3.4",
+        "colorjs.io": "^0.5.2",
+        "escodegen": "^2.1.0",
+        "file-saver": "^1.3.8",
+        "gifenc": "^1.0.3",
+        "i18next": "^19.0.2",
+        "i18next-browser-languagedetector": "^4.0.1",
+        "libtess": "^1.2.2",
+        "omggif": "^1.0.10",
+        "pako": "^2.1.0",
+        "pixelmatch": "^7.1.0",
+        "zod": "^3.23.8"
+      }
+    },
+    "node_modules/p5/node_modules/acorn-walk": {
+      "version": "8.3.4",
+      "resolved": "https://registry.npmjs.org/acorn-walk/-/acorn-walk-8.3.4.tgz",
+      "integrity": "sha512-ueEepnujpqee2o5aIYnvHU6C0A42MNdsIDeqy5BydrkuC5R1ZuUFnm27EeFJGoEHJQgn3uleRvmTXaJgfXbt4g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "acorn": "^8.11.0"
+      },
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "node_modules/pako": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/pako/-/pako-2.1.0.tgz",
+      "integrity": "sha512-w+eufiZ1WuJYgPXbV/PO3NCMEc3xqylkKHzp8bxp1uW4qaSNQUkwmLLEc3kKsfz8lpV1F8Ht3U1Cm+9Srog2ug==",
+      "dev": true,
+      "license": "(MIT AND Zlib)"
+    },
     "node_modules/parse5": {
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/parse5/-/parse5-6.0.1.tgz",
@@ -1819,6 +1923,29 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/pixelmatch": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/pixelmatch/-/pixelmatch-7.1.0.tgz",
+      "integrity": "sha512-1wrVzJ2STrpmONHKBy228LM1b84msXDUoAzVEl0R8Mz4Ce6EPr+IVtxm8+yvrqLYMHswREkjYFaMxnyGnaY3Ng==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "pngjs": "^7.0.0"
+      },
+      "bin": {
+        "pixelmatch": "bin/pixelmatch"
+      }
+    },
+    "node_modules/pngjs": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/pngjs/-/pngjs-7.0.0.tgz",
+      "integrity": "sha512-LKWqWJRhstyYo9pGvgor/ivk2w94eSjE3RGVuzLGlr3NmD8bf7RcYGze1mNdEHRP6TRP6rMuDHk5t44hnTRyow==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.19.0"
       }
     },
     "node_modules/postcss": {
@@ -1903,9 +2030,9 @@
       "peer": true
     },
     "node_modules/rollup": {
-      "version": "4.40.0",
-      "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.40.0.tgz",
-      "integrity": "sha512-Noe455xmA96nnqH5piFtLobsGbCij7Tu+tb3c1vYjNbTkfzGqXqQXG3wJaYXkRZuQ0vEYN4bhwg7QnIrqB5B+w==",
+      "version": "4.41.1",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.41.1.tgz",
+      "integrity": "sha512-cPmwD3FnFv8rKMBc1MxWCwVQFxwf1JEmSX3iQXrRVVG15zerAIXRjMFVWnd5Q5QvgKF7Aj+5ykXFhUl+QGnyOw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1919,26 +2046,26 @@
         "npm": ">=8.0.0"
       },
       "optionalDependencies": {
-        "@rollup/rollup-android-arm-eabi": "4.40.0",
-        "@rollup/rollup-android-arm64": "4.40.0",
-        "@rollup/rollup-darwin-arm64": "4.40.0",
-        "@rollup/rollup-darwin-x64": "4.40.0",
-        "@rollup/rollup-freebsd-arm64": "4.40.0",
-        "@rollup/rollup-freebsd-x64": "4.40.0",
-        "@rollup/rollup-linux-arm-gnueabihf": "4.40.0",
-        "@rollup/rollup-linux-arm-musleabihf": "4.40.0",
-        "@rollup/rollup-linux-arm64-gnu": "4.40.0",
-        "@rollup/rollup-linux-arm64-musl": "4.40.0",
-        "@rollup/rollup-linux-loongarch64-gnu": "4.40.0",
-        "@rollup/rollup-linux-powerpc64le-gnu": "4.40.0",
-        "@rollup/rollup-linux-riscv64-gnu": "4.40.0",
-        "@rollup/rollup-linux-riscv64-musl": "4.40.0",
-        "@rollup/rollup-linux-s390x-gnu": "4.40.0",
-        "@rollup/rollup-linux-x64-gnu": "4.40.0",
-        "@rollup/rollup-linux-x64-musl": "4.40.0",
-        "@rollup/rollup-win32-arm64-msvc": "4.40.0",
-        "@rollup/rollup-win32-ia32-msvc": "4.40.0",
-        "@rollup/rollup-win32-x64-msvc": "4.40.0",
+        "@rollup/rollup-android-arm-eabi": "4.41.1",
+        "@rollup/rollup-android-arm64": "4.41.1",
+        "@rollup/rollup-darwin-arm64": "4.41.1",
+        "@rollup/rollup-darwin-x64": "4.41.1",
+        "@rollup/rollup-freebsd-arm64": "4.41.1",
+        "@rollup/rollup-freebsd-x64": "4.41.1",
+        "@rollup/rollup-linux-arm-gnueabihf": "4.41.1",
+        "@rollup/rollup-linux-arm-musleabihf": "4.41.1",
+        "@rollup/rollup-linux-arm64-gnu": "4.41.1",
+        "@rollup/rollup-linux-arm64-musl": "4.41.1",
+        "@rollup/rollup-linux-loongarch64-gnu": "4.41.1",
+        "@rollup/rollup-linux-powerpc64le-gnu": "4.41.1",
+        "@rollup/rollup-linux-riscv64-gnu": "4.41.1",
+        "@rollup/rollup-linux-riscv64-musl": "4.41.1",
+        "@rollup/rollup-linux-s390x-gnu": "4.41.1",
+        "@rollup/rollup-linux-x64-gnu": "4.41.1",
+        "@rollup/rollup-linux-x64-musl": "4.41.1",
+        "@rollup/rollup-win32-arm64-msvc": "4.41.1",
+        "@rollup/rollup-win32-ia32-msvc": "4.41.1",
+        "@rollup/rollup-win32-x64-msvc": "4.41.1",
         "fsevents": "~2.3.2"
       }
     },
@@ -1980,7 +2107,6 @@
       "dev": true,
       "license": "BSD-3-Clause",
       "optional": true,
-      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -2045,9 +2171,9 @@
       "license": "MIT"
     },
     "node_modules/tinyglobby": {
-      "version": "0.2.13",
-      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.13.tgz",
-      "integrity": "sha512-mEwzpUgrLySlveBwEVDMKk5B57bhLPYovRfPAXD5gA/98Opn0rCDj3GtLwFvCvH5RK9uPCExUROW5NjDwvqkxw==",
+      "version": "0.2.14",
+      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.14.tgz",
+      "integrity": "sha512-tX5e7OM1HnYr2+a2C/4V0htOcSQcoSTH9KgJnVvNm5zm/cyEWKJ7j7YutsH9CxMdtOkkLFy2AHrMci9IM8IPZQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -2092,9 +2218,9 @@
       }
     },
     "node_modules/tone": {
-      "version": "15.1.22",
-      "resolved": "https://registry.npmjs.org/tone/-/tone-15.1.22.tgz",
-      "integrity": "sha512-TCScAGD4sLsama5DjvTUXlLDXSqPealhL64nsdV1hhr6frPWve0DeSo63AKnSJwgfg55fhvxj0iPPRwPN5o0ag==",
+      "version": "15.2.6",
+      "resolved": "https://registry.npmjs.org/tone/-/tone-15.2.6.tgz",
+      "integrity": "sha512-iDsIH+h3uAPpq7ogmyCpODPzHEQQjxmWm/jCRTMMsBDEZ3buMBNWXhVwsdt5tiOb5DXTT4YsFApb15KXDD6elw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -2168,9 +2294,9 @@
       }
     },
     "node_modules/vite": {
-      "version": "6.3.4",
-      "resolved": "https://registry.npmjs.org/vite/-/vite-6.3.4.tgz",
-      "integrity": "sha512-BiReIiMS2fyFqbqNT/Qqt4CVITDU9M9vE+DKcVAsB+ZV0wvTKd+3hMbkpxz1b+NmEDMegpVbisKiAZOnvO92Sw==",
+      "version": "6.3.5",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-6.3.5.tgz",
+      "integrity": "sha512-cZn6NDFE7wdTpINgs++ZJ4N49W2vRp8LCKrn3Ob1kYNtOo21vfDoaV5GzBfLU4MovSAB8uNRm4jgzVQZ+mBzPQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -2243,15 +2369,15 @@
       }
     },
     "node_modules/vite-node": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/vite-node/-/vite-node-3.1.2.tgz",
-      "integrity": "sha512-/8iMryv46J3aK13iUXsei5G/A3CUlW4665THCPS+K8xAaqrVWiGB4RfXMQXCLjpK9P2eK//BczrVkn5JLAk6DA==",
+      "version": "3.1.4",
+      "resolved": "https://registry.npmjs.org/vite-node/-/vite-node-3.1.4.tgz",
+      "integrity": "sha512-6enNwYnpyDo4hEgytbmc6mYWHXDHYEn0D1/rw4Q+tnHUGtKTJsn8T1YkX6Q18wI5LCrS8CTYlBaiCqxOy2kvUA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "cac": "^6.7.14",
         "debug": "^4.4.0",
-        "es-module-lexer": "^1.6.0",
+        "es-module-lexer": "^1.7.0",
         "pathe": "^2.0.3",
         "vite": "^5.0.0 || ^6.0.0"
       },
@@ -2266,19 +2392,19 @@
       }
     },
     "node_modules/vitest": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/vitest/-/vitest-3.1.2.tgz",
-      "integrity": "sha512-WaxpJe092ID1C0mr+LH9MmNrhfzi8I65EX/NRU/Ld016KqQNRgxSOlGNP1hHN+a/F8L15Mh8klwaF77zR3GeDQ==",
+      "version": "3.1.4",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-3.1.4.tgz",
+      "integrity": "sha512-Ta56rT7uWxCSJXlBtKgIlApJnT6e6IGmTYxYcmxjJ4ujuZDI59GUQgVDObXXJujOmPDBYXHK1qmaGtneu6TNIQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@vitest/expect": "3.1.2",
-        "@vitest/mocker": "3.1.2",
-        "@vitest/pretty-format": "^3.1.2",
-        "@vitest/runner": "3.1.2",
-        "@vitest/snapshot": "3.1.2",
-        "@vitest/spy": "3.1.2",
-        "@vitest/utils": "3.1.2",
+        "@vitest/expect": "3.1.4",
+        "@vitest/mocker": "3.1.4",
+        "@vitest/pretty-format": "^3.1.4",
+        "@vitest/runner": "3.1.4",
+        "@vitest/snapshot": "3.1.4",
+        "@vitest/spy": "3.1.4",
+        "@vitest/utils": "3.1.4",
         "chai": "^5.2.0",
         "debug": "^4.4.0",
         "expect-type": "^1.2.1",
@@ -2291,7 +2417,7 @@
         "tinypool": "^1.0.2",
         "tinyrainbow": "^2.0.0",
         "vite": "^5.0.0 || ^6.0.0",
-        "vite-node": "3.1.2",
+        "vite-node": "3.1.4",
         "why-is-node-running": "^2.3.0"
       },
       "bin": {
@@ -2307,8 +2433,8 @@
         "@edge-runtime/vm": "*",
         "@types/debug": "^4.1.12",
         "@types/node": "^18.0.0 || ^20.0.0 || >=22.0.0",
-        "@vitest/browser": "3.1.2",
-        "@vitest/ui": "3.1.2",
+        "@vitest/browser": "3.1.4",
+        "@vitest/ui": "3.1.4",
         "happy-dom": "*",
         "jsdom": "*"
       },
@@ -2480,6 +2606,16 @@
       "license": "MIT",
       "optional": true,
       "peer": true
+    },
+    "node_modules/zod": {
+      "version": "3.25.32",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.32.tgz",
+      "integrity": "sha512-OSm2xTIRfW8CV5/QKgngwmQW/8aPfGdaQFlrGoErlgg/Epm7cjb6K6VEyExfe65a3VybUOnu381edLb0dfJl0g==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
+      }
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -10,7 +10,8 @@
   "author": "Peter Gagliardi",
   "license": "Apache-2.0",
   "devDependencies": {
-    "tone": "^15.1.22",
-    "vitest": "^3.0.5"
+    "p5": "^2.0.2",
+    "tone": "^15.2.6",
+    "vitest": "^3.1.4"
   }
 }

--- a/sketchlib/AnimationChain.js
+++ b/sketchlib/AnimationChain.js
@@ -1,7 +1,11 @@
 import { Point } from "../pga2d/objects.js";
 import { Motor } from "../pga2d/versors.js";
 import { Color } from "./Color.js";
-import { GroupPrimitive, LinePrimitive, PointPrimitive } from "./primitives.js";
+import {
+  GroupPrimitive,
+  LinePrimitive,
+  PointPrimitive,
+} from "./rendering/primitives.js";
 import { Style } from "./Style.js";
 
 const SPINE_STYLE = Style.DEFAULT_STROKE;

--- a/sketchlib/AnimationChain.js
+++ b/sketchlib/AnimationChain.js
@@ -1,11 +1,8 @@
 import { Point } from "../pga2d/objects.js";
 import { Motor } from "../pga2d/versors.js";
 import { Color } from "./Color.js";
-import {
-  GroupPrimitive,
-  LinePrimitive,
-  PointPrimitive,
-} from "./rendering/primitives.js";
+import { GroupPrimitive } from "./rendering/GroupPrimitive.js";
+import { LinePrimitive, PointPrimitive } from "./rendering/primitives.js";
 import { Style } from "./Style.js";
 
 const SPINE_STYLE = Style.DEFAULT_STROKE;
@@ -158,10 +155,10 @@ export class AnimationChain {
     for (let i = 0; i < lines.length; i++) {
       lines[i] = new LinePrimitive(positions[i], positions[i + 1]);
     }
-    const spine_group = new GroupPrimitive(lines, SPINE_STYLE);
+    const spine_group = new GroupPrimitive(lines, { style: SPINE_STYLE });
 
     const centers = positions.map((x) => new PointPrimitive(x));
-    const centers_group = new GroupPrimitive(centers, CENTER_STYLE);
+    const centers_group = new GroupPrimitive(centers, { style: CENTER_STYLE });
 
     return new GroupPrimitive([spine_group, centers_group]);
   }

--- a/sketchlib/draw_primitive.js
+++ b/sketchlib/draw_primitive.js
@@ -11,7 +11,7 @@ import {
   BeziergonPrimitive,
   VectorPrimitive,
   TextPrimitive,
-} from "./primitives.js";
+} from "./rendering/primitives.js";
 
 function draw_rect(p, rect) {
   const { x, y } = rect.position;

--- a/sketchlib/p5_helpers/draw_primitive.js
+++ b/sketchlib/p5_helpers/draw_primitive.js
@@ -1,5 +1,5 @@
-import { Point } from "../pga2d/objects.js";
-import { Motor } from "../pga2d/versors.js";
+import { Point } from "../../pga2d/objects.js";
+import { Motor } from "../../pga2d/versors.js";
 import {
   LinePrimitive,
   RectPrimitive,
@@ -11,7 +11,7 @@ import {
   BeziergonPrimitive,
   VectorPrimitive,
   TextPrimitive,
-} from "./rendering/primitives.js";
+} from "../rendering/primitives.js";
 
 function draw_rect(p, rect) {
   const { x, y } = rect.position;

--- a/sketchlib/p5_helpers/draw_primitive.js
+++ b/sketchlib/p5_helpers/draw_primitive.js
@@ -200,7 +200,7 @@ function apply_text_style(p, text_style) {
     ? get_vertical_align(p, text_style.v_align)
     : undefined;
 
-  if (h_align && v_align) {
+  if (h_align || v_align) {
     p.textAlign(h_align, v_align);
   }
 }

--- a/sketchlib/rendering/GroupPrimitive.js
+++ b/sketchlib/rendering/GroupPrimitive.js
@@ -29,10 +29,12 @@ export class GroupPrimitive {
    * @param {GroupSettings} [settings] Optional settings to apply to everything in the group.
    */
   constructor(primitives, settings) {
+    // For convenience, if there is a single primitive, wrap it in an array
     if (!Array.isArray(primitives)) {
-      throw new Error("primitives must be an array of Primitive");
+      primitives = [primitives];
     }
     this.primitives = primitives;
+
     this.style = settings.style;
     this.transform = settings.transform;
     this.text_style = settings.text_style;

--- a/sketchlib/rendering/GroupPrimitive.js
+++ b/sketchlib/rendering/GroupPrimitive.js
@@ -1,10 +1,10 @@
+import { Style } from "../Style.js";
+import { TextStyle } from "./TextStyle.js";
+import { Transform } from "./Transform.js";
+
 /**
  * @typedef {import("./primitives").SimplePrimitive | GroupPrimitive} Primitive
  */
-
-import { Style } from "../Style";
-import { TextStyle } from "./TextStyle";
-import { Transform } from "./Transform";
 
 /**
  * @typedef {{
@@ -35,6 +35,7 @@ export class GroupPrimitive {
     }
     this.primitives = primitives;
 
+    settings = settings ?? {};
     this.style = settings.style;
     this.transform = settings.transform;
     this.text_style = settings.text_style;
@@ -44,3 +45,4 @@ export class GroupPrimitive {
     yield* this.primitives;
   }
 }
+GroupPrimitive.EMPTY = Object.freeze(new GroupPrimitive([]));

--- a/sketchlib/rendering/GroupPrimitive.js
+++ b/sketchlib/rendering/GroupPrimitive.js
@@ -1,0 +1,44 @@
+/**
+ * @typedef {import("./primitives").SimplePrimitive | GroupPrimitive} Primitive
+ */
+
+import { Style } from "../Style";
+import { TextStyle } from "./TextStyle";
+import { Transform } from "./Transform";
+
+/**
+ * @typedef {{
+ *  style?: Style,
+ *  text_style?: TextStyle,
+ *  transform?: Transform
+ * }} GroupSettings
+ */
+
+/**
+ * A logical grouping of primitives to be rendered together, in the order
+ * listed in the primitives array. This is the main way to apply styling and
+ * transformations to primitives.
+ *
+ * Note: GroupPrimitive can be nested, but the most specific settings will
+ * be applied.
+ */
+export class GroupPrimitive {
+  /**
+   * Constructor
+   * @param {Primitive | Primitive[]} primitives The primitive(s) to store in the group
+   * @param {GroupSettings} [settings] Optional settings to apply to everything in the group.
+   */
+  constructor(primitives, settings) {
+    if (!Array.isArray(primitives)) {
+      throw new Error("primitives must be an array of Primitive");
+    }
+    this.primitives = primitives;
+    this.style = settings.style;
+    this.transform = settings.transform;
+    this.text_style = settings.text_style;
+  }
+
+  *[Symbol.iterator]() {
+    yield* this.primitives;
+  }
+}

--- a/sketchlib/rendering/TextStyle.js
+++ b/sketchlib/rendering/TextStyle.js
@@ -1,0 +1,18 @@
+/**
+ * Style information for text. Only settings that are explicitly set will
+ * be applied in p5.js
+ */
+export class TextStyle {
+  /**
+   * Constructor
+   * @param {number} [size] Text size
+   * @param {"left" | "center" | "right"} [h_align] How to align the text horizontally
+   * @param {"top" | "bottom" | "center" | "baseline"} [v_align] how to align the text vertically
+   */
+  constructor(size, h_align, v_align) {
+    this.size = size;
+    this.align = h_align;
+    this.v_align = v_align;
+  }
+}
+TextStyle.DEFAULT = Object.freeze(new TextStyle());

--- a/sketchlib/rendering/TextStyle.js
+++ b/sketchlib/rendering/TextStyle.js
@@ -11,7 +11,7 @@ export class TextStyle {
    */
   constructor(size, h_align, v_align) {
     this.size = size;
-    this.align = h_align;
+    this.h_align = h_align;
     this.v_align = v_align;
   }
 }

--- a/sketchlib/rendering/Transform.js
+++ b/sketchlib/rendering/Transform.js
@@ -6,8 +6,8 @@ import { Point } from "../../pga2d/objects";
  */
 export class Transform {
   /**
-   *
-   * @param {Point} translation
+   * Constructor
+   * @param {Point} translation The translation amount
    */
   constructor(translation) {
     this.translation = translation;

--- a/sketchlib/rendering/Transform.js
+++ b/sketchlib/rendering/Transform.js
@@ -1,0 +1,15 @@
+import { Point } from "../../pga2d/objects";
+
+/**
+ * A transformation that can be converted to p5 commands. Right now
+ * this only supports translation
+ */
+export class Transform {
+  /**
+   *
+   * @param {Point} translation
+   */
+  constructor(translation) {
+    this.translation = translation;
+  }
+}

--- a/sketchlib/rendering/Transform.js
+++ b/sketchlib/rendering/Transform.js
@@ -1,4 +1,4 @@
-import { Point } from "../../pga2d/objects";
+import { Point } from "../../pga2d/objects.js";
 
 /**
  * A transformation that can be converted to p5 commands. Right now

--- a/sketchlib/rendering/primitives.js
+++ b/sketchlib/rendering/primitives.js
@@ -1,27 +1,57 @@
-import { Point } from "../pga2d/objects.js";
-import { Style } from "./Style.js";
+import { Point } from "../../pga2d/objects.js";
 
+/**
+ * A single point. This is rendered as a small circle of fixed size.
+ */
 export class PointPrimitive {
+  /**
+   * Constructor
+   * @param {Point} position The position for this point
+   */
   constructor(position) {
     this.position = position;
   }
 }
 
+/**
+ * A circle with a center and radius
+ */
 export class CirclePrimitive {
+  /**
+   * Constructor
+   * @param {Point} position The center of the circle
+   * @param {number} radius The radius of the circle
+   */
   constructor(position, radius) {
     this.position = position;
     this.radius = radius;
   }
 }
 
+/**
+ * Rectangle
+ */
 export class RectPrimitive {
+  /**
+   * Constructor
+   * @param {Point} position The top left corner of the rectangle as a Point.point
+   * @param {Point} dimensions The dimensions of the rectangle as a Point.direction
+   */
   constructor(position, dimensions) {
     this.position = position;
     this.dimensions = dimensions;
   }
 }
 
+/**
+ * Line segment
+ */
 export class LinePrimitive {
+  /**
+   * Constructor
+   * @param {Point} a The start point
+   * @param {Point} b The end point
+   */
   constructor(a, b) {
     this.a = a;
     this.b = b;
@@ -43,7 +73,17 @@ export class VectorPrimitive {
   }
 }
 
+/**
+ * Cubic Bezier curve
+ */
 export class BezierPrimitive {
+  /**
+   * Constructor
+   * @param {Point} a Start point
+   * @param {Point} b First tangent point
+   * @param {Point} c Second tangent point
+   * @param {Point} d End point
+   */
   constructor(a, b, c, d) {
     this.a = a;
     this.b = b;
@@ -51,6 +91,15 @@ export class BezierPrimitive {
     this.d = d;
   }
 
+  /**
+   * Convert from a B-spline to a bezier curve. B-splines can be used to
+   * smooth out a sharp polygon into a smooth curve.
+   * @param {Point} b0 First control point
+   * @param {Point} b1 Second control point
+   * @param {Point} b2 Third control point
+   * @param {Point} b3 Fourth control point
+   * @returns {BezierPrimitive} The equivalent Bezier curve
+   */
   static from_b_spline(b0, b1, b2, b3) {
     // See https://en.wikipedia.org/wiki/B-spline#Cubic_B-Splines
 
@@ -83,7 +132,14 @@ export class BezierPrimitive {
   }
 }
 
+/**
+ * A closed polygon
+ */
 export class PolygonPrimitive {
+  /**
+   * Constructor
+   * @param {Point[]} vertices Vertices of the polygon. Do not repeat the first point, closing the polygon is handled automatically.
+   */
   constructor(vertices) {
     this.vertices = vertices;
   }
@@ -93,7 +149,14 @@ export class PolygonPrimitive {
   }
 }
 
+/**
+ * A curved polygon where the edges are Bezier curves
+ */
 export class BeziergonPrimitive {
+  /**
+   * Constructor
+   * @param {BezierPrimitive[]} curves The
+   */
   constructor(curves) {
     this.curves = curves;
   }
@@ -120,66 +183,20 @@ export class BeziergonPrimitive {
 }
 
 /**
- * Temporary for now
- * @private
- */
-export class TextStyle {
-  /**
-   *
-   * @param {number} size
-   * @param {"left" | "center"} align How to align the text
-   */
-  constructor(size, align) {
-    this.size = size;
-    this.align = align;
-  }
-}
-
-/**
- * Temporary, I need to
- * @private
+ * Text primitive
  */
 export class TextPrimitive {
   /**
-   *
+   * Constructor
    * @param {string} text The text to display
    * @param {Point} position The position to anchor the text
-   * @param {TextStyle} text_style The style for the text
    */
-  constructor(text, position, text_style) {
+  constructor(text, position) {
     this.text = text;
     this.position = position;
-    this.text_style = text_style;
   }
 }
 
 /**
- * A logical grouping of primitives to be rendered together, in the order
- * listed in the primitives array. This is the main way to apply styling to
- * primitives.
- *
- * Note: GroupPrimitive can be nested, but the most specific style will be the
- * one that's applied.
- */
-export class GroupPrimitive {
-  /**
-   * Constructor
-   * @param {Primitive[]} primitives The primitives in this group
-   * @param {Style} [style] An optional style to apply to these primitives.
-   */
-  constructor(primitives, style) {
-    if (!Array.isArray(primitives)) {
-      throw new Error("primitives must be an array of Primitive");
-    }
-    this.primitives = primitives;
-    this.style = style;
-  }
-
-  *[Symbol.iterator]() {
-    yield* this.primitives;
-  }
-}
-
-/**
- * @typedef {GroupPrimitive | BezierPrimitive | PolygonPrimitive | BezierPrimitive | LinePrimitive | RectPrimitive | CirclePrimitive | PointPrimitive | BeziergonPrimitive | VectorPrimitive | TextPrimitive} Primitive
+ * @typedef {BezierPrimitive | PolygonPrimitive | BezierPrimitive | LinePrimitive | RectPrimitive | CirclePrimitive | PointPrimitive | BeziergonPrimitive | VectorPrimitive | TextPrimitive} SimplePrimitive
  */

--- a/sketchlib/rendering/primitives.test.js
+++ b/sketchlib/rendering/primitives.test.js
@@ -1,7 +1,7 @@
 import { describe, it, expect } from "vitest";
-import { Point } from "../pga2d/objects";
+import { Point } from "../../pga2d/objects";
 import { BezierPrimitive } from "./primitives";
-import { PGA_MATCHERS } from "../pga2d/pga_matchers";
+import { PGA_MATCHERS } from "../../pga2d/pga_matchers";
 
 expect.extend(PGA_MATCHERS);
 


### PR DESCRIPTION
Redo the `GroupPrimitive` class to:

- include text styling
- include transformations. Right now this is only translations
- Allow specifying a single primitive without needing to wrap in an array

To try out the transformations, `SoundTest` now makes the musical timeline from #56 scroll to the left, rather than the cursor.