### PR TITLE
Make a chord progression based on a 4-bit counter

### DIFF
--- a/lab/SoundTest/SoundTest.js
+++ b/lab/SoundTest/SoundTest.js
@@ -1,6 +1,7 @@
 import { Point } from "../../pga2d/objects.js";
 import { Color } from "../../sketchlib/Color.js";
 import { WIDTH, HEIGHT } from "../../sketchlib/dimensions.js";
+import { Grid, Index2D } from "../../sketchlib/Grid.js";
 import { draw_primitive } from "../../sketchlib/p5_helpers/draw_primitive.js";
 import { GroupPrimitive } from "../../sketchlib/rendering/GroupPrimitive.js";
 import {
@@ -11,6 +12,7 @@ import { TextStyle } from "../../sketchlib/rendering/TextStyle.js";
 import { Transform } from "../../sketchlib/rendering/Transform.js";
 import { Style } from "../../sketchlib/Style.js";
 import { CanvasMouseHandler } from "../lablib/CanvasMouseHandler.js";
+import { MouseInput } from "../lablib/MouseInput.js";
 import { render_score } from "../lablib/music/render_score.js";
 import { MuteButton } from "../lablib/MuteButton.js";
 import { Oklch } from "../lablib/Oklch.js";
@@ -19,6 +21,7 @@ import { Rectangle } from "../lablib/Rectangle.js";
 import { SoundManager } from "../lablib/SoundManager.js";
 import { TouchButton } from "../lablib/TouchButton.js";
 import {
+  binary_progression,
   layered_melody,
   phase_scale,
   symmetry_melody,
@@ -29,9 +32,10 @@ const MOUSE = new CanvasMouseHandler();
 /**@type {import("../lablib/SoundManager.js").SoundManifest} */
 const SOUND_MANIFEST = {
   scores: {
-    melody_a: layered_melody(),
-    melody_b: phase_scale(),
-    melody_c: symmetry_melody(),
+    layered_melody: layered_melody(),
+    phase_scale: phase_scale(),
+    symmetry_melody: symmetry_melody(),
+    binary_progression: binary_progression(),
   },
 };
 
@@ -62,14 +66,68 @@ for (const [key, score] of Object.entries(SOUND_MANIFEST.scores)) {
 //@ts-ignore
 const SOUND = new SoundManager(Tone, SOUND_MANIFEST);
 
-const MARGIN = 50;
+class MelodyButtonDescriptor {
+  /**
+   * Data associated with a melody button
+   * @param {string} id The id of the melody to play
+   * @param {string} label The human-readable label for the button
+   */
+  constructor(id, label) {
+    this.id = id;
+    this.label = label;
+  }
+}
+
+const MELODY_BUTTONS = new Grid(2, 2);
+MELODY_BUTTONS.set(
+  new Index2D(0, 0),
+  new MelodyButtonDescriptor("layered_melody", "Layered Melody")
+);
+MELODY_BUTTONS.set(
+  new Index2D(0, 1),
+  new MelodyButtonDescriptor("phase_scale", "Phase Scale")
+);
+MELODY_BUTTONS.set(
+  new Index2D(1, 0),
+  new MelodyButtonDescriptor("symmetry_melody", "Symmetry Melody")
+);
+MELODY_BUTTONS.set(
+  new Index2D(1, 1),
+  new MelodyButtonDescriptor("binary_progression", "4-bit Chords")
+);
+
+const FIRST_BUTTON_OFFSET = Point.direction(50, HEIGHT / 2);
 const MELODY_BUTTON_SIZE = 150;
 const MELODY_BUTTON_DIMENSIONS = Point.direction(
   MELODY_BUTTON_SIZE,
-  MELODY_BUTTON_SIZE
+  MELODY_BUTTON_SIZE / 2
 );
+const MELODY_BUTTON_CENTER_OFFSET = MELODY_BUTTON_DIMENSIONS.scale(0.5);
+const TEXT_STYLE = new TextStyle(16, "center", "center");
+const TEXT_COLOR = new Style({
+  fill: Color.WHITE,
+});
+/**
+ * Make the text primitives for the buttons.
+ * @param {Grid<MelodyButtonDescriptor>} buttons The button descriptions
+ * @return {GroupPrimitive} A single group containing all the text
+ */
+function make_button_labels(buttons) {
+  const primitives = buttons.map_array((index, descriptor) => {
+    const point = index.to_world(
+      FIRST_BUTTON_OFFSET.add(MELODY_BUTTON_CENTER_OFFSET),
+      MELODY_BUTTON_DIMENSIONS
+    );
+    return new TextPrimitive(descriptor.label, point);
+  });
 
-const TEXT_STYLE = new TextStyle(24, "center", "center");
+  return new GroupPrimitive(primitives, {
+    style: TEXT_COLOR,
+    text_style: TEXT_STYLE,
+  });
+}
+
+/*
 const TEXT_A = new TextPrimitive(
   "Melody A",
   Point.point(MARGIN + MELODY_BUTTON_SIZE / 2, HEIGHT / 2)
@@ -83,13 +141,12 @@ const TEXT_C = new TextPrimitive(
   Point.point(MARGIN + MELODY_BUTTON_SIZE / 2, HEIGHT / 2 + MELODY_BUTTON_SIZE)
 );
 
-const TEXT_COLOR = new Style({
-  fill: Color.WHITE,
-});
 const BUTTON_LABELS = new GroupPrimitive([TEXT_A, TEXT_B, TEXT_C], {
   style: TEXT_COLOR,
   text_style: TEXT_STYLE,
-});
+});*/
+
+const BUTTON_LABELS = make_button_labels(MELODY_BUTTONS);
 
 const TIMELINE_TOP = HEIGHT / 8;
 
@@ -102,11 +159,15 @@ const CURSOR = new GroupPrimitive(
 );
 
 class SoundScene {
-  constructor(sound) {
+  /**
+   * Constructor
+   * @param {SoundManager} sound Reference to the sound manager
+   * @param {Grid<MelodyButtonDescriptor>} melodies The melodies to create buttons for
+   */
+  constructor(sound, melodies) {
     this.sound = sound;
     this.mute_button = new MuteButton();
     this.events = new EventTarget();
-
     this.mute_button.events.addEventListener(
       "change",
       (/** @type {CustomEvent}*/ e) => {
@@ -114,55 +175,33 @@ class SoundScene {
       }
     );
 
-    this.melody_a_button = new TouchButton(
-      new Rectangle(
-        Point.point(MARGIN, HEIGHT / 2 - MELODY_BUTTON_SIZE / 2),
-        MELODY_BUTTON_DIMENSIONS
-      )
-    );
-
-    this.melody_b_button = new TouchButton(
-      new Rectangle(
-        Point.point(
-          WIDTH - MARGIN - MELODY_BUTTON_SIZE,
-          HEIGHT / 2 - MELODY_BUTTON_SIZE / 2
-        ),
-        MELODY_BUTTON_DIMENSIONS
-      )
-    );
-
-    this.melody_c_button = new TouchButton(
-      new Rectangle(
-        Point.point(MARGIN, HEIGHT / 2 + MELODY_BUTTON_SIZE / 2),
-        MELODY_BUTTON_DIMENSIONS
-      )
-    );
-
+    /**
+     * ID of the score currently playing
+     * @type {string}
+     */
     this.selected_melody = undefined;
 
-    this.melody_a_button.events.addEventListener("click", () => {
-      this.selected_melody = "melody_a";
-      this.sound.play_score(this.selected_melody);
-    });
-
-    this.melody_b_button.events.addEventListener("click", () => {
-      this.selected_melody = "melody_b";
-      this.sound.play_score(this.selected_melody);
-    });
-
-    this.melody_c_button.events.addEventListener("click", () => {
-      this.selected_melody = "melody_c";
-      this.sound.play_score(this.selected_melody);
+    this.melody_buttons = melodies.map_array((index, descriptor) => {
+      const corner = index.to_world(
+        FIRST_BUTTON_OFFSET,
+        MELODY_BUTTON_DIMENSIONS
+      );
+      const rectangle = new Rectangle(corner, MELODY_BUTTON_DIMENSIONS);
+      const button = new TouchButton(rectangle);
+      button.events.addEventListener("click", () => {
+        this.selected_melody = descriptor.id;
+        this.sound.play_score(this.selected_melody);
+      });
+      return button;
     });
   }
 
   render() {
     const mute = this.mute_button.render();
-    const melody_a = this.melody_a_button.debug_render();
-    const melody_b = this.melody_b_button.debug_render();
-    const melody_c = this.melody_c_button.debug_render();
 
-    const primitives = [mute, melody_a, melody_b, melody_c, BUTTON_LABELS];
+    const melody_buttons = this.melody_buttons.map((x) => x.debug_render());
+
+    const primitives = [mute, ...melody_buttons, BUTTON_LABELS];
 
     if (this.selected_melody !== undefined) {
       const current_time = SOUND.transport_time;
@@ -181,35 +220,47 @@ class SoundScene {
 
   update() {}
 
+  /**
+   *
+   * @param {MouseInput} input
+   */
   mouse_pressed(input) {
     this.mute_button.mouse_pressed(input);
-    this.melody_a_button.mouse_pressed(input.mouse_coords);
-    this.melody_b_button.mouse_pressed(input.mouse_coords);
-    this.melody_c_button.mouse_pressed(input.mouse_coords);
+    this.melody_buttons.forEach((x) => x.mouse_pressed(input.mouse_coords));
   }
 
+  /**
+   *
+   * @param {MouseInput} input
+   */
   mouse_moved(input) {
     this.mute_button.mouse_moved(input);
-    this.melody_a_button.mouse_moved(input.mouse_coords);
-    this.melody_b_button.mouse_moved(input.mouse_coords);
-    this.melody_c_button.mouse_moved(input.mouse_coords);
+    this.melody_buttons.forEach((x) => x.mouse_moved(input.mouse_coords));
   }
 
+  /**
+   *
+   * @param {MouseInput} input
+   */
   mouse_dragged(input) {
     this.mute_button.mouse_dragged(input);
-    this.melody_a_button.mouse_dragged(input.mouse_coords);
-    this.melody_b_button.mouse_dragged(input.mouse_coords);
-    this.melody_c_button.mouse_dragged(input.mouse_coords);
+    this.melody_buttons.forEach((x) => x.mouse_moved(input.mouse_coords));
   }
 
+  /**
+   *
+   * @param {MouseInput} input
+   */
   mouse_released(input) {
     this.mute_button.mouse_released(input);
-    this.melody_a_button.mouse_released(input.mouse_coords);
-    this.melody_b_button.mouse_released(input.mouse_coords);
-    this.melody_c_button.mouse_released(input.mouse_coords);
+    this.melody_buttons.forEach((x) => x.mouse_released(input.mouse_coords));
   }
 }
 
+/**
+ *
+ * @param {import("p5")} p
+ */
 export const sketch = (p) => {
   /** @type {PlayButtonScene | SoundScene} */
   let scene = new PlayButtonScene(SOUND);
@@ -224,7 +275,7 @@ export const sketch = (p) => {
     MOUSE.setup(canvas);
 
     scene.events.addEventListener("scene-change", () => {
-      scene = new SoundScene(SOUND);
+      scene = new SoundScene(SOUND, MELODY_BUTTONS);
     });
   };
 

--- a/lab/SoundTest/SoundTest.js
+++ b/lab/SoundTest/SoundTest.js
@@ -96,7 +96,6 @@ MELODY_BUTTONS.set(
   new MelodyButtonDescriptor("binary_progression", "4-bit Chords")
 );
 
-const FIRST_BUTTON_OFFSET = Point.direction(50, HEIGHT / 2);
 const MELODY_BUTTON_SIZE = 150;
 const MELODY_BUTTON_DIMENSIONS = Point.direction(
   MELODY_BUTTON_SIZE,
@@ -107,6 +106,18 @@ const TEXT_STYLE = new TextStyle(16, "center", "center");
 const TEXT_COLOR = new Style({
   fill: Color.WHITE,
 });
+
+const GRID_BOUNDARY = new Rectangle(
+  Point.point(0, HEIGHT / 2),
+  Point.direction(WIDTH, HEIGHT / 2)
+);
+const GRID_MARGIN = Point.direction(75, 80);
+const [BUTTON_OFFSET, BUTTON_STRIDE] = MELODY_BUTTONS.compute_layout(
+  GRID_BOUNDARY,
+  MELODY_BUTTON_DIMENSIONS,
+  GRID_MARGIN
+);
+
 /**
  * Make the text primitives for the buttons.
  * @param {Grid<MelodyButtonDescriptor>} buttons The button descriptions
@@ -115,8 +126,8 @@ const TEXT_COLOR = new Style({
 function make_button_labels(buttons) {
   const primitives = buttons.map_array((index, descriptor) => {
     const point = index.to_world(
-      FIRST_BUTTON_OFFSET.add(MELODY_BUTTON_CENTER_OFFSET),
-      MELODY_BUTTON_DIMENSIONS
+      BUTTON_OFFSET.add(MELODY_BUTTON_CENTER_OFFSET),
+      BUTTON_STRIDE
     );
     return new TextPrimitive(descriptor.label, point);
   });
@@ -163,10 +174,7 @@ class SoundScene {
     this.selected_melody = undefined;
 
     this.melody_buttons = melodies.map_array((index, descriptor) => {
-      const corner = index.to_world(
-        FIRST_BUTTON_OFFSET,
-        MELODY_BUTTON_DIMENSIONS
-      );
+      const corner = index.to_world(BUTTON_OFFSET, BUTTON_STRIDE);
       const rectangle = new Rectangle(corner, MELODY_BUTTON_DIMENSIONS);
       const button = new TouchButton(rectangle);
       button.events.addEventListener("click", () => {

--- a/lab/SoundTest/SoundTest.js
+++ b/lab/SoundTest/SoundTest.js
@@ -21,7 +21,7 @@ import { Rectangle } from "../lablib/Rectangle.js";
 import { SoundManager } from "../lablib/SoundManager.js";
 import { TouchButton } from "../lablib/TouchButton.js";
 import {
-  binary_progression,
+  binary_chords,
   layered_melody,
   phase_scale,
   symmetry_melody,
@@ -35,7 +35,7 @@ const SOUND_MANIFEST = {
     layered_melody: layered_melody(),
     phase_scale: phase_scale(),
     symmetry_melody: symmetry_melody(),
-    binary_progression: binary_progression(),
+    binary_progression: binary_chords(),
   },
 };
 

--- a/lab/SoundTest/SoundTest.js
+++ b/lab/SoundTest/SoundTest.js
@@ -127,25 +127,6 @@ function make_button_labels(buttons) {
   });
 }
 
-/*
-const TEXT_A = new TextPrimitive(
-  "Melody A",
-  Point.point(MARGIN + MELODY_BUTTON_SIZE / 2, HEIGHT / 2)
-);
-const TEXT_B = new TextPrimitive(
-  "Melody B",
-  Point.point(WIDTH - MARGIN - MELODY_BUTTON_SIZE / 2, HEIGHT / 2)
-);
-const TEXT_C = new TextPrimitive(
-  "Melody C",
-  Point.point(MARGIN + MELODY_BUTTON_SIZE / 2, HEIGHT / 2 + MELODY_BUTTON_SIZE)
-);
-
-const BUTTON_LABELS = new GroupPrimitive([TEXT_A, TEXT_B, TEXT_C], {
-  style: TEXT_COLOR,
-  text_style: TEXT_STYLE,
-});*/
-
 const BUTTON_LABELS = make_button_labels(MELODY_BUTTONS);
 
 const TIMELINE_TOP = HEIGHT / 8;

--- a/lab/SoundTest/example_scores.js
+++ b/lab/SoundTest/example_scores.js
@@ -241,7 +241,6 @@ export function binary_chords() {
    * @type {Boolean[][]}
    */
   const bits_lsb = range(16).map((x) => to_bits(x, 4));
-  const bits_msb = [...bits_lsb].reverse();
 
   /**
    * @type {Melody<Number>}
@@ -249,8 +248,12 @@ export function binary_chords() {
   const upwards_progression = new Melody(
     ...bits_lsb.map((x) => bit_chord(x, major_seventh, silence))
   );
+
+  // For the second half, flip the bit patterns vertically while keeping the
+  // pitches in the same rows. This makes the chord start on the 7th and work
+  // downwards
   const downwards_progression = new Melody(
-    ...bits_msb.map((x) => bit_chord(x, major_seventh, silence))
+    ...bits_lsb.map((x) => bit_chord([...x].reverse(), major_seventh, silence))
   );
 
   const full_progression = new Melody(

--- a/lab/SoundTest/example_scores.js
+++ b/lab/SoundTest/example_scores.js
@@ -5,13 +5,16 @@ import {
   B,
   B4,
   C,
+  C2,
   C3,
   C4,
   D,
   E,
+  E3,
   E4,
   F,
   G,
+  G3,
   G4,
   GS,
   REST,
@@ -199,10 +202,10 @@ function range(n) {
 }
 
 /**
- * Take a number and convert to bits
- * @param {number} x
+ * Take a number and convert to bits. They are returned in LSB order
+ * @param {number} x A number
  * @param {number} width how many bits wide should the results be
- * @returns An array of size width storing the bits
+ * @returns An array of size width storing the bits.
  */
 function to_bits(x, width) {
   const bits = new Array(width).fill(0).map((_, i) => Boolean((x >> i) & 1));
@@ -224,13 +227,11 @@ function bit_chord(bit_pattern, chord_notes, silence) {
   );
 }
 
-export function binary_progression() {
+export function binary_chords() {
   const chord_duration = N1;
-  const major_seventh_upwards = [C4, E4, G4, B4].map(
+  const major_seventh = [B4, G4, E4, C4].map(
     (x) => new Note(x, chord_duration)
   );
-
-  const major_seventh_downwards = [...major_seventh_upwards].reverse();
 
   const silence = new Rest(chord_duration);
 
@@ -239,16 +240,17 @@ export function binary_progression() {
   /**
    * @type {Boolean[][]}
    */
-  const bit_patterns4 = range(16).map((x) => to_bits(x, 4));
+  const bits_lsb = range(16).map((x) => to_bits(x, 4));
+  const bits_msb = [...bits_lsb].reverse();
 
   /**
    * @type {Melody<Number>}
    */
   const upwards_progression = new Melody(
-    ...bit_patterns4.map((x) => bit_chord(x, major_seventh_upwards, silence))
+    ...bits_lsb.map((x) => bit_chord(x, major_seventh, silence))
   );
   const downwards_progression = new Melody(
-    ...bit_patterns4.map((x) => bit_chord(x, major_seventh_downwards, silence))
+    ...bits_msb.map((x) => bit_chord(x, major_seventh, silence))
   );
 
   const full_progression = new Melody(
@@ -256,9 +258,8 @@ export function binary_progression() {
     downwards_progression
   );
 
-  const bass_drone = C3;
-  const drone = new Note(bass_drone, full_progression.duration);
+  const rhythm_bass = parse_cycle(N1, [C3, [C3, G3], C3, [C3, G3]]);
+  const rhythm_loop = new MusicLoop(full_progression.duration, rhythm_bass);
 
-  const part = new Harmony(full_progression, drone);
-  return new Score(["poly", part]);
+  return new Score(["supersaw", full_progression], ["square", rhythm_loop]);
 }

--- a/sketchlib/Grid.js
+++ b/sketchlib/Grid.js
@@ -1,3 +1,4 @@
+import { Rectangle } from "../lab/lablib/Rectangle.js";
 import { Point } from "../pga2d/objects.js";
 import { Direction } from "./Direction.js";
 
@@ -315,5 +316,33 @@ export class Grid {
       index.left(),
       this.down(index),
     ].filter((x) => x !== undefined && this.in_bounds(x));
+  }
+
+  /**
+   * Evenly space items of item_size within the bounding rectangle according
+   * to the number of rows/columns in this grid.
+   * @param {Rectangle} boundary The bounding rectangle
+   * @param {Point} item_size The size of each item as a Point.direction
+   * @param {Point} margin How much space to leave around the x or y direction (note that this will be doubled). Any remaining space will be used as padding
+   * @return {[Point, Point]} [offset, stride] The computed offset and stride
+   */
+  compute_layout(boundary, item_size, margin) {
+    // If we arranged the items as tightly as possible, how big would this
+    // rectangle be?
+    const total_item_space = Point.direction(
+      item_size.x * this.cols,
+      item_size.y * this.rows
+    );
+    const remaining_space = boundary.dimensions.sub(total_item_space);
+    const padding = remaining_space.sub(margin.scale(2));
+
+    const padding_size = Point.direction(
+      padding.x / (this.cols - 1),
+      padding.y / (this.rows - 1)
+    );
+
+    const offset = boundary.position.add(margin);
+    const stride = item_size.add(padding_size);
+    return [offset, stride];
   }
 }

--- a/sketchlib/Grid.js
+++ b/sketchlib/Grid.js
@@ -1,3 +1,4 @@
+import { Point } from "../pga2d/objects.js";
 import { Direction } from "./Direction.js";
 
 /**
@@ -110,6 +111,19 @@ export class Index2D {
     }
 
     return undefined;
+  }
+
+  /**
+   * Convert an index (assumed to be row-major) to a point in the world
+   * @param {Point} offset The offset in units of the world as a Point.point
+   * @param {Point} stride A Point.direction for the stride
+   * @returns {Point} A point in the world
+   */
+  to_world(offset, stride) {
+    const { i, j } = this;
+    const { x, y } = offset;
+    const { x: dx, y: dy } = stride;
+    return Point.direction(x + j * dx, y + i * dy);
   }
 }
 

--- a/sketchlib/Grid.test.js
+++ b/sketchlib/Grid.test.js
@@ -1,6 +1,11 @@
 import { describe, it, expect, test } from "vitest";
 import { Grid, griderator, Index2D } from "./Grid";
 import { Direction } from "./Direction";
+import { Rectangle } from "../lab/lablib/Rectangle";
+import { Point } from "../pga2d/objects";
+import { PGA_MATCHERS } from "../pga2d/pga_matchers";
+
+expect.extend(PGA_MATCHERS);
 
 describe("Index2D", () => {
   it("throws for negative row", () => {
@@ -101,6 +106,30 @@ describe("Index2D", () => {
         expect(result).toBe(expected);
       }
     );
+  });
+
+  describe("to_world", () => {
+    it("computes correct position without offset", () => {
+      const index = new Index2D(1, 3);
+      const offset = Point.ORIGIN;
+      const stride = Point.direction(2, 4);
+
+      const result = index.to_world(offset, stride);
+
+      const expected = Point.direction(6, 4);
+      expect(result).toBePoint(expected);
+    });
+
+    it("computes correct position with offset", () => {
+      const index = new Index2D(1, 3);
+      const offset = Point.point(4, 4);
+      const stride = Point.direction(2, 4);
+
+      const result = index.to_world(offset, stride);
+
+      const expected = Point.direction(10, 8);
+      expect(result).toBePoint(expected);
+    });
   });
 });
 
@@ -387,5 +416,63 @@ describe("Grid", () => {
       new Index2D(2, 0),
     ];
     expect(result).toEqual(expected);
+  });
+
+  describe("compute_layout", () => {
+    it("computes a layout without spacing or margins", () => {
+      const grid = new Grid(2, 2);
+      const boundary = new Rectangle(Point.ORIGIN, Point.direction(4, 4));
+      const item_size = Point.direction(2, 2);
+      const margin = Point.ZERO;
+
+      const [offset, stride] = grid.compute_layout(boundary, item_size, margin);
+
+      const expected_offset = Point.ORIGIN;
+      const expected_stride = Point.direction(2, 2);
+      expect(offset).toBePoint(expected_offset);
+      expect(stride).toBePoint(expected_stride);
+    });
+
+    it("computes a layout with margins", () => {
+      const grid = new Grid(2, 2);
+      const boundary = new Rectangle(Point.ORIGIN, Point.direction(8, 12));
+      const item_size = Point.direction(2, 2);
+      const margin = Point.direction(2, 4);
+
+      const [offset, stride] = grid.compute_layout(boundary, item_size, margin);
+
+      const expected_offset = Point.point(2, 4);
+      const expected_stride = Point.direction(2, 2);
+      expect(offset).toBePoint(expected_offset);
+      expect(stride).toBePoint(expected_stride);
+    });
+
+    it("computes a layout with spacing", () => {
+      const grid = new Grid(2, 2);
+      const boundary = new Rectangle(Point.ORIGIN, Point.direction(8, 10));
+      const item_size = Point.direction(2, 2);
+      const margin = Point.ZERO;
+
+      const [offset, stride] = grid.compute_layout(boundary, item_size, margin);
+
+      const expected_offset = Point.ORIGIN;
+      const expected_stride = Point.direction(6, 8);
+      expect(offset).toBePoint(expected_offset);
+      expect(stride).toBePoint(expected_stride);
+    });
+
+    it("computes a layout with spacing and margins", () => {
+      const grid = new Grid(3, 3);
+      const boundary = new Rectangle(Point.ORIGIN, Point.direction(16, 8));
+      const item_size = Point.direction(2, 2);
+      const margin = Point.direction(4, 1);
+
+      const [offset, stride] = grid.compute_layout(boundary, item_size, margin);
+
+      const expected_offset = Point.point(4, 1);
+      const expected_stride = Point.direction(3, 2);
+      expect(offset).toBePoint(expected_offset);
+      expect(stride).toBePoint(expected_stride);
+    });
   });
 });


### PR DESCRIPTION
This PR:

- Adds a new chord progression to `SoundTest`
- Makes it easier to add more buttons for melodies
- Adds some methods to `Grid, Index2D` to make it easier to lay out grids on the screen (here used for laying out the grid of buttons)