### PR TITLE
Shorthand for grouping/styling primitives

### DIFF
--- a/Anabaena/Anabaena.js
+++ b/Anabaena/Anabaena.js
@@ -14,7 +14,7 @@ import {
 import { Style } from "../sketchlib/Style.js";
 import { Color } from "../sketchlib/Color.js";
 import { GroupPrimitive } from "../sketchlib/rendering/GroupPrimitive.js";
-import { style } from "../sketchlib/rendering/shorthand.js";
+import { group, style } from "../sketchlib/rendering/shorthand.js";
 
 const INITIAL_POSITION = Point.point(WIDTH / 2, HEIGHT - 50);
 const MIN_BEND_ANGLE = (7 * Math.PI) / 8;
@@ -229,10 +229,10 @@ class AnabaenaCatenula {
     ];
 
     if (show_arrows) {
-      primitives.push(new GroupPrimitive(arrows, { style: STYLE_ARROW }));
+      primitives.push(style(arrows, STYLE_ARROW));
     }
 
-    return new GroupPrimitive(primitives);
+    return group(...primitives);
   }
 }
 

--- a/Anabaena/Anabaena.js
+++ b/Anabaena/Anabaena.js
@@ -14,6 +14,7 @@ import {
 import { Style } from "../sketchlib/Style.js";
 import { Color } from "../sketchlib/Color.js";
 import { GroupPrimitive } from "../sketchlib/rendering/GroupPrimitive.js";
+import { style } from "../sketchlib/rendering/shorthand.js";
 
 const INITIAL_POSITION = Point.point(WIDTH / 2, HEIGHT - 50);
 const MIN_BEND_ANGLE = (7 * Math.PI) / 8;
@@ -223,8 +224,8 @@ class AnabaenaCatenula {
     }
 
     const primitives = [
-      new GroupPrimitive(l_cells, { style: STYLE_CELL_L }),
-      new GroupPrimitive(s_cells, { style: STYLE_CELL_S }),
+      style(l_cells, STYLE_CELL_L),
+      style(s_cells, STYLE_CELL_S),
     ];
 
     if (show_arrows) {

--- a/Coral/Maze/Maze.js
+++ b/Coral/Maze/Maze.js
@@ -16,7 +16,7 @@ import {
 } from "../styles.js";
 import { Grid } from "../../sketchlib/Grid.js";
 import { GroupPrimitive } from "../../sketchlib/rendering/GroupPrimitive.js";
-import { style } from "../../sketchlib/rendering/shorthand.js";
+import { group, style } from "../../sketchlib/rendering/shorthand.js";
 
 const WIDTH = 500;
 const HEIGHT = 700;
@@ -54,7 +54,7 @@ function make_tiles_from_tileset(grid, coral_tiles) {
 function render_splines(tile_grid) {
   const splines = find_splines(tile_grid);
   const spline_prims = splines.flatMap((x) => x.to_bezier_world());
-  return style(spline_prims, { style: SPLINE_STYLE });
+  return style(spline_prims, SPLINE_STYLE);
 }
 
 function render_connections(tile_grid) {
@@ -63,7 +63,7 @@ function render_connections(tile_grid) {
       return render_tile_connections(tile);
     })
     .flat();
-  return style(connection_prims, { style: CONNECTION_STYLE });
+  return style(connection_prims, CONNECTION_STYLE);
 }
 
 function render_walls(tile_grid) {
@@ -72,14 +72,14 @@ function render_walls(tile_grid) {
       return render_tile_walls(tile);
     })
     .flat();
-  return style(wall_prims, { style: WALL_STYLE });
+  return style(wall_prims, WALL_STYLE);
 }
 
 function render_geometry(tile_grid) {
   const connections = render_connections(tile_grid);
   const walls = render_walls(tile_grid);
   const splines = render_splines(tile_grid);
-  return style([connections, walls, splines]);
+  return group(connections, walls, splines);
 }
 
 function slurp_json(file) {

--- a/Coral/Maze/Maze.js
+++ b/Coral/Maze/Maze.js
@@ -16,6 +16,7 @@ import {
 } from "../styles.js";
 import { Grid } from "../../sketchlib/Grid.js";
 import { GroupPrimitive } from "../../sketchlib/rendering/GroupPrimitive.js";
+import { style } from "../../sketchlib/rendering/shorthand.js";
 
 const WIDTH = 500;
 const HEIGHT = 700;
@@ -34,7 +35,7 @@ QUADS.fill((index) => {
 const QUAD_PRIMS = QUADS.map_array((_, quad) => {
   return render_quad(quad);
 }).flat();
-const QUAD_GROUP = new GroupPrimitive(QUAD_PRIMS, { style: GRID_STYLE });
+const QUAD_GROUP = style(QUAD_PRIMS, GRID_STYLE);
 
 function make_default_tiles(grid) {
   return grid.map((index, cell) => {
@@ -53,7 +54,7 @@ function make_tiles_from_tileset(grid, coral_tiles) {
 function render_splines(tile_grid) {
   const splines = find_splines(tile_grid);
   const spline_prims = splines.flatMap((x) => x.to_bezier_world());
-  return new GroupPrimitive(spline_prims, { style: SPLINE_STYLE });
+  return style(spline_prims, { style: SPLINE_STYLE });
 }
 
 function render_connections(tile_grid) {
@@ -62,7 +63,7 @@ function render_connections(tile_grid) {
       return render_tile_connections(tile);
     })
     .flat();
-  return new GroupPrimitive(connection_prims, { style: CONNECTION_STYLE });
+  return style(connection_prims, { style: CONNECTION_STYLE });
 }
 
 function render_walls(tile_grid) {
@@ -71,14 +72,14 @@ function render_walls(tile_grid) {
       return render_tile_walls(tile);
     })
     .flat();
-  return new GroupPrimitive(wall_prims, { style: WALL_STYLE });
+  return style(wall_prims, { style: WALL_STYLE });
 }
 
 function render_geometry(tile_grid) {
   const connections = render_connections(tile_grid);
   const walls = render_walls(tile_grid);
   const splines = render_splines(tile_grid);
-  return new GroupPrimitive([connections, walls, splines]);
+  return style([connections, walls, splines]);
 }
 
 function slurp_json(file) {

--- a/Coral/TileEditor/TileEditor.js
+++ b/Coral/TileEditor/TileEditor.js
@@ -25,6 +25,7 @@ import {
 import { Color } from "../../sketchlib/Color.js";
 import { Direction } from "../../sketchlib/Direction.js";
 import { GroupPrimitive } from "../../sketchlib/rendering/GroupPrimitive.js";
+import { group, style } from "../../sketchlib/rendering/shorthand.js";
 
 const WIDTH = 500;
 const HEIGHT = 700;
@@ -91,14 +92,10 @@ function render_control_points(tiles) {
   }
 
   // It's important to draw the points over the line
-  const tangent_line_group = style(tangent_lines, {
-    style: TANGENT_STYLE,
-  });
-  const vertex_group = style(vertices, { style: VERTEX_STYLE });
-  const tangent_group = style(tangent_tips, {
-    style: TANGENT_TIP_STYLE,
-  });
-  return group([tangent_line_group, vertex_group, tangent_group]);
+  const tangent_line_group = style(tangent_lines, TANGENT_STYLE);
+  const vertex_group = style(vertices, VERTEX_STYLE);
+  const tangent_group = style(tangent_tips, TANGENT_TIP_STYLE);
+  return group(tangent_line_group, vertex_group, tangent_group);
 }
 
 const HIGHLIGHT_RADIUS = 8;
@@ -107,27 +104,25 @@ function highlight_selection(selected_object) {
     selected_object.position_world,
     HIGHLIGHT_RADIUS
   );
-  return style([circle], { style: HIGHLIGHT_STYLE });
+  return style(circle, HIGHLIGHT_STYLE);
 }
 
 const QUAD_PRIMS = SMALL_QUADS.map_array((_, quad) => {
   return render_quad(quad);
 }).flat();
-const QUADS = style(QUAD_PRIMS, { style: GRID_STYLE });
+const QUADS = style(QUAD_PRIMS, GRID_STYLE);
 
 const CONNECTION_PRIMS = TILES.map_array((_, tile) => {
   return render_tile_connections(tile);
 }).flat();
-const CONNECTIONS = style(CONNECTION_PRIMS, {
-  style: CONNECTION_STYLE,
-});
+const CONNECTIONS = style(CONNECTION_PRIMS, CONNECTION_STYLE);
 
 const WALL_PRIMS = TILES.map_array((_, tile) => {
   return render_tile_walls(tile);
 }).flat();
-const WALLS = style(WALL_PRIMS, { style: WALL_STYLE });
+const WALLS = style(WALL_PRIMS, WALL_STYLE);
 
-const STATIC_GEOMETRY = group([QUADS, CONNECTIONS, WALLS]);
+const STATIC_GEOMETRY = group(QUADS, CONNECTIONS, WALLS);
 
 // serialize a 16-tile tileset of coral shapes from the tiles in the editor.
 function serialize_tileset(tiles) {
@@ -157,7 +152,7 @@ function you_wouldnt_download_a_json(json, fname) {
 
 function update_spline_primitives() {
   const spline_prims = SPLINES.flatMap((x) => x.to_bezier_world());
-  return style(spline_prims, { style: SPLINE_STYLE });
+  return style(spline_prims, SPLINE_STYLE);
 }
 
 export const sketch = (p) => {

--- a/Coral/TileEditor/TileEditor.js
+++ b/Coral/TileEditor/TileEditor.js
@@ -91,14 +91,14 @@ function render_control_points(tiles) {
   }
 
   // It's important to draw the points over the line
-  const tangent_line_group = new GroupPrimitive(tangent_lines, {
+  const tangent_line_group = style(tangent_lines, {
     style: TANGENT_STYLE,
   });
-  const vertex_group = new GroupPrimitive(vertices, { style: VERTEX_STYLE });
-  const tangent_group = new GroupPrimitive(tangent_tips, {
+  const vertex_group = style(vertices, { style: VERTEX_STYLE });
+  const tangent_group = style(tangent_tips, {
     style: TANGENT_TIP_STYLE,
   });
-  return new GroupPrimitive([tangent_line_group, vertex_group, tangent_group]);
+  return group([tangent_line_group, vertex_group, tangent_group]);
 }
 
 const HIGHLIGHT_RADIUS = 8;
@@ -107,27 +107,27 @@ function highlight_selection(selected_object) {
     selected_object.position_world,
     HIGHLIGHT_RADIUS
   );
-  return new GroupPrimitive([circle], { style: HIGHLIGHT_STYLE });
+  return style([circle], { style: HIGHLIGHT_STYLE });
 }
 
 const QUAD_PRIMS = SMALL_QUADS.map_array((_, quad) => {
   return render_quad(quad);
 }).flat();
-const QUADS = new GroupPrimitive(QUAD_PRIMS, { style: GRID_STYLE });
+const QUADS = style(QUAD_PRIMS, { style: GRID_STYLE });
 
 const CONNECTION_PRIMS = TILES.map_array((_, tile) => {
   return render_tile_connections(tile);
 }).flat();
-const CONNECTIONS = new GroupPrimitive(CONNECTION_PRIMS, {
+const CONNECTIONS = style(CONNECTION_PRIMS, {
   style: CONNECTION_STYLE,
 });
 
 const WALL_PRIMS = TILES.map_array((_, tile) => {
   return render_tile_walls(tile);
 }).flat();
-const WALLS = new GroupPrimitive(WALL_PRIMS, { style: WALL_STYLE });
+const WALLS = style(WALL_PRIMS, { style: WALL_STYLE });
 
-const STATIC_GEOMETRY = new GroupPrimitive([QUADS, CONNECTIONS, WALLS]);
+const STATIC_GEOMETRY = group([QUADS, CONNECTIONS, WALLS]);
 
 // serialize a 16-tile tileset of coral shapes from the tiles in the editor.
 function serialize_tileset(tiles) {
@@ -157,7 +157,7 @@ function you_wouldnt_download_a_json(json, fname) {
 
 function update_spline_primitives() {
   const spline_prims = SPLINES.flatMap((x) => x.to_bezier_world());
-  return new GroupPrimitive(spline_prims, { style: SPLINE_STYLE });
+  return style(spline_prims, { style: SPLINE_STYLE });
 }
 
 export const sketch = (p) => {

--- a/DifferentialGrowth/DifferentialPolyline.js
+++ b/DifferentialGrowth/DifferentialPolyline.js
@@ -231,7 +231,7 @@ export class DifferentialPolyline {
     );
 
     const beziergon = BeziergonPrimitive.interpolate_points(positions);
-    return new GroupPrimitive(beziergon, { style });
+    return style(beziergon, { style });
   }
 
   make_polyline(style) {
@@ -239,7 +239,7 @@ export class DifferentialPolyline {
       Point.point(x.position.x, x.position.y)
     );
     const polygon = new PolygonPrimitive(vertices);
-    return new GroupPrimitive(polygon, { style });
+    return style(polygon, { style });
   }
 
   draw(p, fill_color) {

--- a/DifferentialGrowth/DifferentialPolyline.js
+++ b/DifferentialGrowth/DifferentialPolyline.js
@@ -10,6 +10,7 @@ import { Circle } from "./circle.js";
 import { mod } from "../sketchlib/mod.js";
 import { HEIGHT, WIDTH } from "../sketchlib/dimensions.js";
 import { GroupPrimitive } from "../sketchlib/rendering/GroupPrimitive.js";
+import { style } from "../sketchlib/rendering/shorthand.js";
 
 const MAX_EDGE_LENGTH = 150;
 
@@ -225,21 +226,21 @@ export class DifferentialPolyline {
     }
   }
 
-  make_curve(style) {
+  make_curve(line_style) {
     const positions = this.nodes.map((node) =>
       Point.point(node.position.x, node.position.y)
     );
 
     const beziergon = BeziergonPrimitive.interpolate_points(positions);
-    return style(beziergon, { style });
+    return style(beziergon, line_style);
   }
 
-  make_polyline(style) {
+  make_polyline(line_style) {
     const vertices = this.nodes.map((x) =>
       Point.point(x.position.x, x.position.y)
     );
     const polygon = new PolygonPrimitive(vertices);
-    return style(polygon, { style });
+    return style(polygon, line_style);
   }
 
   draw(p, fill_color) {

--- a/MosaicSlider/InteractiveMosaic.js
+++ b/MosaicSlider/InteractiveMosaic.js
@@ -146,7 +146,7 @@ export class InteractiveMosaic {
     const grid = this.grid.render();
 
     if (this.swap_pair) {
-      return new GroupPrimitive([grid, this.swap_pair.render(frame)]);
+      return group([grid, this.swap_pair.render(frame)]);
     }
     return grid;
   }

--- a/MosaicSlider/InteractiveMosaic.js
+++ b/MosaicSlider/InteractiveMosaic.js
@@ -1,6 +1,7 @@
 import { Point } from "../pga2d/objects.js";
 import { Color } from "../sketchlib/Color.js";
 import { GroupPrimitive } from "../sketchlib/rendering/GroupPrimitive.js";
+import { group } from "../sketchlib/rendering/shorthand.js";
 import { MosaicGrid } from "./MosaicGrid.js";
 
 const SliderState = {
@@ -146,7 +147,7 @@ export class InteractiveMosaic {
     const grid = this.grid.render();
 
     if (this.swap_pair) {
-      return group([grid, this.swap_pair.render(frame)]);
+      return group(grid, this.swap_pair.render(frame));
     }
     return grid;
   }

--- a/MosaicSlider/MosaicGrid.js
+++ b/MosaicSlider/MosaicGrid.js
@@ -146,9 +146,9 @@ export class MosaicGrid {
       by_colors[color_index].push(rect);
     });
     const color_groups = by_colors.map((x, i) => {
-      return new GroupPrimitive(x, { style: this.styles[i] });
+      return style(x, { style: this.styles[i] });
     });
-    return new GroupPrimitive(color_groups);
+    return group(color_groups);
   }
 
   /**

--- a/MosaicSlider/MosaicGrid.js
+++ b/MosaicSlider/MosaicGrid.js
@@ -8,6 +8,7 @@ import { in_bounds } from "../sketchlib/in_bounds.js";
 import { sec_to_frames } from "../sketchlib/Tween.js";
 import { Color } from "../sketchlib/Color.js";
 import { GroupPrimitive } from "../sketchlib/rendering/GroupPrimitive.js";
+import { group, style } from "../sketchlib/rendering/shorthand.js";
 
 const ROWS = 16;
 const COLS = 16;
@@ -146,9 +147,9 @@ export class MosaicGrid {
       by_colors[color_index].push(rect);
     });
     const color_groups = by_colors.map((x, i) => {
-      return style(x, { style: this.styles[i] });
+      return style(x, this.styles[i]);
     });
-    return group(color_groups);
+    return group(...color_groups);
   }
 
   /**

--- a/MosaicSlider/PixelSwapPair.js
+++ b/MosaicSlider/PixelSwapPair.js
@@ -65,11 +65,11 @@ export class PixelSwapPair {
     const square_b = new RectPrimitive(b_position, this.pixel_dimensions);
     const square_a = new RectPrimitive(a_position, this.pixel_dimensions);
 
-    const group_b = new GroupPrimitive([square_b], { style: this.style_b });
-    const group_a = new GroupPrimitive([square_a], { style: this.style_a });
+    const group_b = style([square_b], { style: this.style_b });
+    const group_a = style([square_a], { style: this.style_a });
 
     // square b must be rendered before square a so the pixel we want to
     // move is on top.
-    return new GroupPrimitive([group_b, group_a]);
+    return group([group_b, group_a]);
   }
 }

--- a/MosaicSlider/PixelSwapPair.js
+++ b/MosaicSlider/PixelSwapPair.js
@@ -1,6 +1,7 @@
 import { Point } from "../pga2d/objects.js";
 import { GroupPrimitive } from "../sketchlib/rendering/GroupPrimitive.js";
 import { RectPrimitive } from "../sketchlib/rendering/primitives.js";
+import { group, style } from "../sketchlib/rendering/shorthand.js";
 import { Style } from "../sketchlib/Style.js";
 import { Tween } from "../sketchlib/Tween.js";
 
@@ -65,11 +66,11 @@ export class PixelSwapPair {
     const square_b = new RectPrimitive(b_position, this.pixel_dimensions);
     const square_a = new RectPrimitive(a_position, this.pixel_dimensions);
 
-    const group_b = style([square_b], { style: this.style_b });
-    const group_a = style([square_a], { style: this.style_a });
+    const group_b = style([square_b], this.style_b);
+    const group_a = style([square_a], this.style_a);
 
     // square b must be rendered before square a so the pixel we want to
     // move is on top.
-    return group([group_b, group_a]);
+    return group(group_b, group_a);
   }
 }

--- a/PerspectiveRailroad/PerspectiveRailroad.js
+++ b/PerspectiveRailroad/PerspectiveRailroad.js
@@ -166,15 +166,15 @@ function make_background() {
     Point.point(0, 0),
     Point.direction(WIDTH, VP_RAILS.y)
   );
-  const sky = new GroupPrimitive(sky_prim, { style: SKY_STYLE });
+  const sky = style(sky_prim, { style: SKY_STYLE });
 
   const ground_prim = new RectPrimitive(
     Point.point(0, VP_RAILS.y),
     Point.direction(WIDTH, HEIGHT - VP_RAILS.y)
   );
-  const ground = new GroupPrimitive(ground_prim, { style: GROUND_STYLE });
+  const ground = style(ground_prim, { style: GROUND_STYLE });
 
-  return new GroupPrimitive([sky, ground]);
+  return group([sky, ground]);
 }
 
 class AnimatedTie {
@@ -309,12 +309,12 @@ export const sketch = (p) => {
     const tie_prims = ANIMATED_TIES.map((x) =>
       x.compute_polygon(p.frameCount)
     ).filter((x) => x !== undefined);
-    const ties = new GroupPrimitive(tie_prims, { style: TIE_STYLE });
+    const ties = style(tie_prims, { style: TIE_STYLE });
 
     const rail_prims = ANIMATED_RAILS.compute_polygons(p.frameCount);
-    const rails = new GroupPrimitive(rail_prims, { style: RAIL_STYLE });
+    const rails = style(rail_prims, { style: RAIL_STYLE });
 
-    const dynamic_geom = new GroupPrimitive([ties, rails]);
+    const dynamic_geom = group([ties, rails]);
 
     draw_primitive(p, BACKGROUND);
     draw_primitive(p, dynamic_geom);

--- a/PerspectiveRailroad/PerspectiveRailroad.js
+++ b/PerspectiveRailroad/PerspectiveRailroad.js
@@ -7,6 +7,7 @@ import { Style } from "../sketchlib/Style.js";
 import { draw_primitive } from "../sketchlib/p5_helpers/draw_primitive.js";
 import { Color } from "../sketchlib/Color.js";
 import { GroupPrimitive } from "../sketchlib/rendering/GroupPrimitive.js";
+import { group, style } from "../sketchlib/rendering/shorthand.js";
 
 const WIDTH = 500;
 const HEIGHT = 700;
@@ -166,15 +167,15 @@ function make_background() {
     Point.point(0, 0),
     Point.direction(WIDTH, VP_RAILS.y)
   );
-  const sky = style(sky_prim, { style: SKY_STYLE });
+  const sky = style(sky_prim, SKY_STYLE);
 
   const ground_prim = new RectPrimitive(
     Point.point(0, VP_RAILS.y),
     Point.direction(WIDTH, HEIGHT - VP_RAILS.y)
   );
-  const ground = style(ground_prim, { style: GROUND_STYLE });
+  const ground = style(ground_prim, GROUND_STYLE);
 
-  return group([sky, ground]);
+  return group(sky, ground);
 }
 
 class AnimatedTie {
@@ -309,12 +310,12 @@ export const sketch = (p) => {
     const tie_prims = ANIMATED_TIES.map((x) =>
       x.compute_polygon(p.frameCount)
     ).filter((x) => x !== undefined);
-    const ties = style(tie_prims, { style: TIE_STYLE });
+    const ties = style(tie_prims, TIE_STYLE);
 
     const rail_prims = ANIMATED_RAILS.compute_polygons(p.frameCount);
-    const rails = style(rail_prims, { style: RAIL_STYLE });
+    const rails = style(rail_prims, RAIL_STYLE);
 
-    const dynamic_geom = group([ties, rails]);
+    const dynamic_geom = group(ties, rails);
 
     draw_primitive(p, BACKGROUND);
     draw_primitive(p, dynamic_geom);

--- a/Worm/AnimatedWorm.js
+++ b/Worm/AnimatedWorm.js
@@ -12,6 +12,7 @@ import { AnimationChain, Joint } from "../sketchlib/AnimationChain.js";
 import { is_nearly } from "../sketchlib/is_nearly.js";
 import { GooglyEye } from "./GooglyEye.js";
 import { GroupPrimitive } from "../sketchlib/rendering/GroupPrimitive.js";
+import { group, style } from "../sketchlib/rendering/shorthand.js";
 
 const WORM_SEGMENTS = 60;
 const WORM_SEGMENT_SEPARATION = 30;
@@ -120,12 +121,12 @@ export class AnimatedWorm {
     for (let i = 0; i < lines.length; i++) {
       lines[i] = new LinePrimitive(positions[i], positions[i + 1]);
     }
-    const spine_group = style(lines, { style: SPINE_STYLE });
+    const spine_group = style(lines, SPINE_STYLE);
 
     const centers = positions.map((x) => new PointPrimitive(x));
-    const centers_group = style(centers, { style: CENTER_STYLE });
+    const centers_group = style(centers, CENTER_STYLE);
 
-    return style([spine_group, centers_group]);
+    return group(spine_group, centers_group);
   }
 
   compute_circles() {
@@ -199,7 +200,7 @@ export class AnimatedWorm {
     const all_points = left.concat(tail_points, right, head_points);
     const beziergon = BeziergonPrimitive.interpolate_points(all_points);
 
-    return style(beziergon, { style: WORM_STYLE });
+    return style(beziergon, WORM_STYLE);
   }
 
   render_eyes() {
@@ -213,7 +214,7 @@ export class AnimatedWorm {
     const right_position = center.add(right_dir.scale(WORM_EYE_SEPARATION));
     left.update(left_position, this.look_direction);
     right.update(right_position, this.look_direction);
-    return style([left.render(), right.render()]);
+    return group(left.render(), right.render());
   }
 
   render() {
@@ -222,9 +223,9 @@ export class AnimatedWorm {
     const body = this.render_body();
     const eyes = this.render_eyes();
     if (DEBUG_SHOW_SPINE) {
-      return style([body, spine, eyes]);
+      return group(body, spine, eyes);
     } else {
-      return style([body, eyes]);
+      return group(body, eyes);
     }
   }
 }

--- a/Worm/AnimatedWorm.js
+++ b/Worm/AnimatedWorm.js
@@ -120,12 +120,12 @@ export class AnimatedWorm {
     for (let i = 0; i < lines.length; i++) {
       lines[i] = new LinePrimitive(positions[i], positions[i + 1]);
     }
-    const spine_group = new GroupPrimitive(lines, { style: SPINE_STYLE });
+    const spine_group = style(lines, { style: SPINE_STYLE });
 
     const centers = positions.map((x) => new PointPrimitive(x));
-    const centers_group = new GroupPrimitive(centers, { style: CENTER_STYLE });
+    const centers_group = style(centers, { style: CENTER_STYLE });
 
-    return new GroupPrimitive([spine_group, centers_group]);
+    return style([spine_group, centers_group]);
   }
 
   compute_circles() {
@@ -199,7 +199,7 @@ export class AnimatedWorm {
     const all_points = left.concat(tail_points, right, head_points);
     const beziergon = BeziergonPrimitive.interpolate_points(all_points);
 
-    return new GroupPrimitive(beziergon, { style: WORM_STYLE });
+    return style(beziergon, { style: WORM_STYLE });
   }
 
   render_eyes() {
@@ -213,7 +213,7 @@ export class AnimatedWorm {
     const right_position = center.add(right_dir.scale(WORM_EYE_SEPARATION));
     left.update(left_position, this.look_direction);
     right.update(right_position, this.look_direction);
-    return new GroupPrimitive([left.render(), right.render()]);
+    return style([left.render(), right.render()]);
   }
 
   render() {
@@ -222,9 +222,9 @@ export class AnimatedWorm {
     const body = this.render_body();
     const eyes = this.render_eyes();
     if (DEBUG_SHOW_SPINE) {
-      return new GroupPrimitive([body, spine, eyes]);
+      return style([body, spine, eyes]);
     } else {
-      return new GroupPrimitive([body, eyes]);
+      return style([body, eyes]);
     }
   }
 }

--- a/Worm/GooglyEye.js
+++ b/Worm/GooglyEye.js
@@ -35,15 +35,15 @@ export class GooglyEye {
       this.position,
       this.sclera_radius
     );
-    const sclera = new GroupPrimitive(sclera_circle, { style: STYLE_SCLERA });
+    const sclera = style(sclera_circle, { style: STYLE_SCLERA });
 
     const pupil_center = this.position.add(
       this.look_direction.scale(this.sclera_radius - this.pupil_radius)
     );
     const pupil_circle = new CirclePrimitive(pupil_center, this.pupil_radius);
-    const pupil = new GroupPrimitive(pupil_circle, { style: STYLE_PUPIL });
+    const pupil = style(pupil_circle, { style: STYLE_PUPIL });
 
-    return new GroupPrimitive([sclera, pupil]);
+    return group([sclera, pupil]);
   }
 
   render() {

--- a/Worm/GooglyEye.js
+++ b/Worm/GooglyEye.js
@@ -2,6 +2,7 @@ import { Point } from "../pga2d/objects.js";
 import { Color } from "../sketchlib/Color.js";
 import { GroupPrimitive } from "../sketchlib/rendering/GroupPrimitive.js";
 import { CirclePrimitive } from "../sketchlib/rendering/primitives.js";
+import { group, style } from "../sketchlib/rendering/shorthand.js";
 import { Style } from "../sketchlib/Style.js";
 
 const STYLE_SCLERA = new Style({ fill: Color.WHITE });
@@ -35,15 +36,15 @@ export class GooglyEye {
       this.position,
       this.sclera_radius
     );
-    const sclera = style(sclera_circle, { style: STYLE_SCLERA });
+    const sclera = style(sclera_circle, STYLE_SCLERA);
 
     const pupil_center = this.position.add(
       this.look_direction.scale(this.sclera_radius - this.pupil_radius)
     );
     const pupil_circle = new CirclePrimitive(pupil_center, this.pupil_radius);
-    const pupil = style(pupil_circle, { style: STYLE_PUPIL });
+    const pupil = style(pupil_circle, STYLE_PUPIL);
 
-    return group([sclera, pupil]);
+    return group(sclera, pupil);
   }
 
   render() {

--- a/lab/DoublePendulum/DoublePendulum.js
+++ b/lab/DoublePendulum/DoublePendulum.js
@@ -2,6 +2,7 @@ import { Point } from "../../pga2d/objects.js";
 import { WIDTH, HEIGHT } from "../../sketchlib/dimensions.js";
 import { draw_primitive } from "../../sketchlib/p5_helpers/draw_primitive.js";
 import { GroupPrimitive } from "../../sketchlib/rendering/GroupPrimitive.js";
+import { group } from "../../sketchlib/rendering/shorthand.js";
 import { DoublePendulumSystem, Pendulum } from "./DoublePendulumSystem.js";
 
 const BOB_MASS = 1.0;
@@ -53,14 +54,14 @@ export const sketch = (p) => {
       THETA_DOT_SCALE
     );
 
-    const scene = group([
+    const scene = group(
       history1,
       history2,
       pendulum_animation,
       phase_axes,
       phase1,
-      phase2,
-    ]);
+      phase2
+    );
 
     draw_primitive(p, scene);
 

--- a/lab/DoublePendulum/DoublePendulum.js
+++ b/lab/DoublePendulum/DoublePendulum.js
@@ -53,7 +53,7 @@ export const sketch = (p) => {
       THETA_DOT_SCALE
     );
 
-    const scene = new GroupPrimitive([
+    const scene = group([
       history1,
       history2,
       pendulum_animation,

--- a/lab/DoublePendulum/DoublePendulumSystem.js
+++ b/lab/DoublePendulum/DoublePendulumSystem.js
@@ -169,8 +169,8 @@ export class DoublePendulumSystem {
     }
 
     return [
-      new GroupPrimitive(phase1, { style: STYLE_PHASE1 }),
-      new GroupPrimitive(phase2, { style: STYLE_PHASE2 }),
+      style(phase1, { style: STYLE_PHASE1 }),
+      style(phase2, { style: STYLE_PHASE2 }),
     ];
   }
 
@@ -190,7 +190,7 @@ export class DoublePendulumSystem {
       new LinePrimitive(origin.sub(theta_dot_dir), origin.add(theta_dot_dir)),
     ];
 
-    return new GroupPrimitive(primitives, { style: STYLE_AXIS });
+    return style(primitives, { style: STYLE_AXIS });
   }
 
   angles_to_positions(origin, theta1, theta2) {
@@ -227,8 +227,8 @@ export class DoublePendulumSystem {
     }
 
     return [
-      new GroupPrimitive(history1, { style: STYLE_PHASE1 }),
-      new GroupPrimitive(history2, { style: STYLE_PHASE2 }),
+      style(history1, { style: STYLE_PHASE1 }),
+      style(history2, { style: STYLE_PHASE2 }),
     ];
   }
 
@@ -257,6 +257,6 @@ export class DoublePendulumSystem {
       PIXELS_PER_METER * this.pendulum2.bob_radius
     );
 
-    return new GroupPrimitive([arm1, arm2, bob1, bob2], { style: ARM_STYLE });
+    return style([arm1, arm2, bob1, bob2], { style: ARM_STYLE });
   }
 }

--- a/lab/DoublePendulum/DoublePendulumSystem.js
+++ b/lab/DoublePendulum/DoublePendulumSystem.js
@@ -11,6 +11,7 @@ import { PI, TAU } from "../../sketchlib/math_consts.js";
 import { mod } from "../../sketchlib/mod.js";
 import { Color } from "../../sketchlib/Color.js";
 import { GroupPrimitive } from "../../sketchlib/rendering/GroupPrimitive.js";
+import { style } from "../../sketchlib/rendering/shorthand.js";
 
 const STYLE_AXIS = Style.DEFAULT_STROKE.with_width(2);
 const ARM_STYLE = STYLE_AXIS;
@@ -168,10 +169,7 @@ export class DoublePendulumSystem {
       }
     }
 
-    return [
-      style(phase1, { style: STYLE_PHASE1 }),
-      style(phase2, { style: STYLE_PHASE2 }),
-    ];
+    return [style(phase1, STYLE_PHASE1), style(phase2, STYLE_PHASE2)];
   }
 
   /**
@@ -190,7 +188,7 @@ export class DoublePendulumSystem {
       new LinePrimitive(origin.sub(theta_dot_dir), origin.add(theta_dot_dir)),
     ];
 
-    return style(primitives, { style: STYLE_AXIS });
+    return style(primitives, STYLE_AXIS);
   }
 
   angles_to_positions(origin, theta1, theta2) {
@@ -226,10 +224,7 @@ export class DoublePendulumSystem {
       history2.push(line2);
     }
 
-    return [
-      style(history1, { style: STYLE_PHASE1 }),
-      style(history2, { style: STYLE_PHASE2 }),
-    ];
+    return [style(history1, STYLE_PHASE1), style(history2, STYLE_PHASE2)];
   }
 
   /**
@@ -257,6 +252,6 @@ export class DoublePendulumSystem {
       PIXELS_PER_METER * this.pendulum2.bob_radius
     );
 
-    return style([arm1, arm2, bob1, bob2], { style: ARM_STYLE });
+    return style([arm1, arm2, bob1, bob2], ARM_STYLE);
   }
 }

--- a/lab/DoubleSpring/DoubleSpring.js
+++ b/lab/DoubleSpring/DoubleSpring.js
@@ -2,6 +2,7 @@ import { Point } from "../../pga2d/objects.js";
 import { WIDTH, HEIGHT } from "../../sketchlib/dimensions.js";
 import { draw_primitive } from "../../sketchlib/p5_helpers/draw_primitive.js";
 import { GroupPrimitive } from "../../sketchlib/rendering/GroupPrimitive.js";
+import { group } from "../../sketchlib/rendering/shorthand.js";
 import { Oklch } from "../lablib/Oklch.js";
 import { DoubleSpringSystem, Spring } from "./DoubleSpringSystem.js";
 
@@ -72,7 +73,7 @@ export const sketch = (p) => {
       return system.render(origin);
     });
 
-    const animations = group(spring_animations);
+    const animations = group(...spring_animations);
 
     const X_SCALE = 300;
     const V_SCALE = 30;
@@ -87,7 +88,7 @@ export const sketch = (p) => {
       return system.render_phase(phase_origin, X_SCALE, V_SCALE);
     });
 
-    const scene = group([...animations, phase_axes, ...phase_animations]);
+    const scene = group(...animations, phase_axes, ...phase_animations);
 
     draw_primitive(p, scene);
 

--- a/lab/DoubleSpring/DoubleSpring.js
+++ b/lab/DoubleSpring/DoubleSpring.js
@@ -72,7 +72,7 @@ export const sketch = (p) => {
       return system.render(origin);
     });
 
-    const animations = new GroupPrimitive(spring_animations);
+    const animations = group(spring_animations);
 
     const X_SCALE = 300;
     const V_SCALE = 30;
@@ -87,11 +87,7 @@ export const sketch = (p) => {
       return system.render_phase(phase_origin, X_SCALE, V_SCALE);
     });
 
-    const scene = new GroupPrimitive([
-      ...animations,
-      phase_axes,
-      ...phase_animations,
-    ]);
+    const scene = group([...animations, phase_axes, ...phase_animations]);
 
     draw_primitive(p, scene);
 

--- a/lab/DoubleSpring/DoubleSpringSystem.js
+++ b/lab/DoubleSpring/DoubleSpringSystem.js
@@ -9,6 +9,7 @@ import { RingBuffer } from "../lablib/RingBuffer.js";
 import { GeneralizedCoordinates } from "../lablib/VectorSpace.js";
 import { Oklch } from "../lablib/Oklch.js";
 import { GroupPrimitive } from "../../sketchlib/rendering/GroupPrimitive.js";
+import { group, style } from "../../sketchlib/rendering/shorthand.js";
 
 const PIXELS_PER_METER = 100;
 const X_METERS = Point.DIR_X.scale(PIXELS_PER_METER);
@@ -47,10 +48,10 @@ export class Spring {
  * @param {Point} position Position of the top left corner of the spring in pixels
  * @param {Point} dimensions Direction encoding the width of the height in pixels
  * @param {number} num_coils How many coils to draw
- * @param {Style} style The style to render the lines with.
+ * @param {Style} line_style The style to render the lines with.
  * @returns {GroupPrimitive} The lines in the spring
  */
-function render_horizontal_spring(position, dimensions, num_coils, style) {
+function render_horizontal_spring(position, dimensions, num_coils, line_style) {
   const { x: w, y: h } = dimensions;
 
   const delta_x = Point.direction(w / num_coils, 0);
@@ -66,7 +67,7 @@ function render_horizontal_spring(position, dimensions, num_coils, style) {
     const diag_up = new LinePrimitive(b, c);
     wires.push(diag_down, diag_up);
   }
-  return style(wires, { style });
+  return style(wires, line_style);
 }
 
 export class DoubleSpringSystem {
@@ -145,8 +146,8 @@ export class DoubleSpringSystem {
     }
 
     return [
-      style(phase1, { style: this.spring1.spring_style }),
-      style(phase2, { style: this.spring2.spring_style }),
+      style(phase1, this.spring1.spring_style),
+      style(phase2, this.spring2.spring_style),
     ];
   }
 
@@ -166,16 +167,15 @@ export class DoubleSpringSystem {
       new LinePrimitive(origin.sub(v_dir), origin.add(v_dir)),
     ];
 
-    return style(primitives, { style: STYLE_AXIS });
+    return style(primitives, STYLE_AXIS);
   }
 
   /**
    * Render the spring system
    * @param {Point} origin The bottom left corner of where the animation will be drawn in pixels
-   * @param {Style} left_spring_style The color of the left spring
    * @returns {GroupPrimitive} The primtitive to render
    */
-  render(origin, left_spring_style) {
+  render(origin) {
     const [x1, , x2] = this.simulation.state;
     const { rest_length: l1, bob_width: w1 } = this.spring1;
     const { rest_length: l2, bob_width: w2 } = this.spring2;
@@ -211,14 +211,10 @@ export class DoubleSpringSystem {
       this.spring2.spring_style
     );
 
-    const walls = style([wall, floor], { style: STYLE_WALLS });
-    const left_bob = style(bob1, {
-      style: this.spring1.bob_style,
-    });
-    const right_bob = style(bob2, {
-      style: this.spring2.bob_style,
-    });
+    const walls = style([wall, floor], STYLE_WALLS);
+    const left_bob = style(bob1, this.spring1.bob_style);
+    const right_bob = style(bob2, this.spring2.bob_style);
 
-    return group([walls, left_spring, right_spring, left_bob, right_bob]);
+    return group(walls, left_spring, right_spring, left_bob, right_bob);
   }
 }

--- a/lab/DoubleSpring/DoubleSpringSystem.js
+++ b/lab/DoubleSpring/DoubleSpringSystem.js
@@ -66,7 +66,7 @@ function render_horizontal_spring(position, dimensions, num_coils, style) {
     const diag_up = new LinePrimitive(b, c);
     wires.push(diag_down, diag_up);
   }
-  return new GroupPrimitive(wires, { style });
+  return style(wires, { style });
 }
 
 export class DoubleSpringSystem {
@@ -145,8 +145,8 @@ export class DoubleSpringSystem {
     }
 
     return [
-      new GroupPrimitive(phase1, { style: this.spring1.spring_style }),
-      new GroupPrimitive(phase2, { style: this.spring2.spring_style }),
+      style(phase1, { style: this.spring1.spring_style }),
+      style(phase2, { style: this.spring2.spring_style }),
     ];
   }
 
@@ -166,7 +166,7 @@ export class DoubleSpringSystem {
       new LinePrimitive(origin.sub(v_dir), origin.add(v_dir)),
     ];
 
-    return new GroupPrimitive(primitives, { style: STYLE_AXIS });
+    return style(primitives, { style: STYLE_AXIS });
   }
 
   /**
@@ -211,20 +211,14 @@ export class DoubleSpringSystem {
       this.spring2.spring_style
     );
 
-    const walls = new GroupPrimitive([wall, floor], { style: STYLE_WALLS });
-    const left_bob = new GroupPrimitive(bob1, {
+    const walls = style([wall, floor], { style: STYLE_WALLS });
+    const left_bob = style(bob1, {
       style: this.spring1.bob_style,
     });
-    const right_bob = new GroupPrimitive(bob2, {
+    const right_bob = style(bob2, {
       style: this.spring2.bob_style,
     });
 
-    return new GroupPrimitive([
-      walls,
-      left_spring,
-      right_spring,
-      left_bob,
-      right_bob,
-    ]);
+    return group([walls, left_spring, right_spring, left_bob, right_bob]);
   }
 }

--- a/lab/PendulumClock/Clock.js
+++ b/lab/PendulumClock/Clock.js
@@ -8,6 +8,7 @@ import {
   LinePrimitive,
   VectorPrimitive,
 } from "../../sketchlib/rendering/primitives.js";
+import { group, style } from "../../sketchlib/rendering/shorthand.js";
 import { Style } from "../../sketchlib/Style.js";
 import { ClockTime } from "./ClockTime.js";
 
@@ -31,9 +32,7 @@ const STYLE_CLOCK = new Style({
   width: 5,
   fill: Color.WHITE,
 });
-const CLOCK_FACE = new GroupPrimitive([CLOCK_CIRCLE, ...CLOCK_HASHES], {
-  style: STYLE_CLOCK,
-});
+const CLOCK_FACE = style([CLOCK_CIRCLE, ...CLOCK_HASHES], STYLE_CLOCK);
 
 const LENGTH_SECOND_HAND = (OUTER_RADIUS * 9) / 10;
 const LENGTH_MINUTE_HAND = (OUTER_RADIUS * 7) / 10;
@@ -86,11 +85,9 @@ function render_clock_hands(time) {
     width: 4,
   });
 
-  const hour_minute = style([hour_hand, minute_hand], {
-    style: style_hands,
-  });
-  const second = style(second_hand, { style: style_second });
-  return group([hour_minute, second]);
+  const hour_minute = style([hour_hand, minute_hand], style_hands);
+  const second = style(second_hand, style_second);
+  return group(hour_minute, second);
 }
 
 /**
@@ -114,9 +111,9 @@ function render_pendulum(time) {
 
   const bob = new CirclePrimitive(bob_center, BOB_RADIUS);
 
-  const pendulum_arm = style(arm, { style: STYLE_ARM });
-  const pendulum_bob = style(bob, { style: STYLE_BOB });
-  return group([pendulum_arm, pendulum_bob]);
+  const pendulum_arm = style(arm, STYLE_ARM);
+  const pendulum_bob = style(bob, STYLE_BOB);
+  return group(pendulum_arm, pendulum_bob);
 }
 
 export class Clock {
@@ -141,6 +138,6 @@ export class Clock {
   render() {
     const pendulum = render_pendulum(this.current_time);
     const clock_hands = render_clock_hands(this.current_time);
-    return group([pendulum, CLOCK_FACE, clock_hands]);
+    return group(pendulum, CLOCK_FACE, clock_hands);
   }
 }

--- a/lab/PendulumClock/Clock.js
+++ b/lab/PendulumClock/Clock.js
@@ -86,11 +86,11 @@ function render_clock_hands(time) {
     width: 4,
   });
 
-  const hour_minute = new GroupPrimitive([hour_hand, minute_hand], {
+  const hour_minute = style([hour_hand, minute_hand], {
     style: style_hands,
   });
-  const second = new GroupPrimitive(second_hand, { style: style_second });
-  return new GroupPrimitive([hour_minute, second]);
+  const second = style(second_hand, { style: style_second });
+  return group([hour_minute, second]);
 }
 
 /**
@@ -114,9 +114,9 @@ function render_pendulum(time) {
 
   const bob = new CirclePrimitive(bob_center, BOB_RADIUS);
 
-  const pendulum_arm = new GroupPrimitive(arm, { style: STYLE_ARM });
-  const pendulum_bob = new GroupPrimitive(bob, { style: STYLE_BOB });
-  return new GroupPrimitive([pendulum_arm, pendulum_bob]);
+  const pendulum_arm = style(arm, { style: STYLE_ARM });
+  const pendulum_bob = style(bob, { style: STYLE_BOB });
+  return group([pendulum_arm, pendulum_bob]);
 }
 
 export class Clock {
@@ -141,6 +141,6 @@ export class Clock {
   render() {
     const pendulum = render_pendulum(this.current_time);
     const clock_hands = render_clock_hands(this.current_time);
-    return new GroupPrimitive([pendulum, CLOCK_FACE, clock_hands]);
+    return group([pendulum, CLOCK_FACE, clock_hands]);
   }
 }

--- a/lab/PendulumClock/PendulumClock.js
+++ b/lab/PendulumClock/PendulumClock.js
@@ -1,6 +1,7 @@
 import { WIDTH, HEIGHT } from "../../sketchlib/dimensions.js";
 import { draw_primitive } from "../../sketchlib/p5_helpers/draw_primitive.js";
 import { GroupPrimitive } from "../../sketchlib/rendering/GroupPrimitive.js";
+import { group } from "../../sketchlib/rendering/shorthand.js";
 import { CanvasMouseHandler } from "../lablib/CanvasMouseHandler.js";
 import { N16, N32, N8 } from "../lablib/music/durations.js";
 import { A3, C4, D4, E4, G4 } from "../lablib/music/pitches.js";
@@ -96,7 +97,7 @@ class PendulumClockScene {
   render() {
     const clock = this.clock.render();
     const mute_button = this.mute_button.render();
-    return group([clock, mute_button]);
+    return group(clock, mute_button);
   }
 
   mouse_pressed(input) {

--- a/lab/PendulumClock/PendulumClock.js
+++ b/lab/PendulumClock/PendulumClock.js
@@ -96,7 +96,7 @@ class PendulumClockScene {
   render() {
     const clock = this.clock.render();
     const mute_button = this.mute_button.render();
-    return new GroupPrimitive([clock, mute_button]);
+    return group([clock, mute_button]);
   }
 
   mouse_pressed(input) {

--- a/lab/SoundTest/SoundTest.js
+++ b/lab/SoundTest/SoundTest.js
@@ -8,6 +8,7 @@ import {
   LinePrimitive,
   TextPrimitive,
 } from "../../sketchlib/rendering/primitives.js";
+import { group, style, xform } from "../../sketchlib/rendering/shorthand.js";
 import { TextStyle } from "../../sketchlib/rendering/TextStyle.js";
 import { Transform } from "../../sketchlib/rendering/Transform.js";
 import { Style } from "../../sketchlib/Style.js";
@@ -147,7 +148,7 @@ const CURSOR = style(
     Point.point(WIDTH / 2, TIMELINE_TOP),
     Point.point(WIDTH / 2, TIMELINE_TOP + HEIGHT / 4)
   ),
-  { style: Style.DEFAULT_STROKE }
+  Style.DEFAULT_STROKE
 );
 
 class SoundScene {
@@ -199,12 +200,12 @@ class SoundScene {
         Point.direction(WIDTH / 2 - x, TIMELINE_TOP)
       );
       const timeline = RENDERED_TIMELINES[this.selected_melody];
-      const shifted = new GroupPrimitive(timeline, { transform });
+      const shifted = xform(timeline, transform);
 
-      return group([...primitives, shifted, CURSOR]);
+      return group(...primitives, shifted, CURSOR);
     }
 
-    return group(primitives);
+    return group(...primitives);
   }
 
   update() {}

--- a/lab/SoundTest/SoundTest.js
+++ b/lab/SoundTest/SoundTest.js
@@ -142,7 +142,7 @@ const BUTTON_LABELS = make_button_labels(MELODY_BUTTONS);
 
 const TIMELINE_TOP = HEIGHT / 8;
 
-const CURSOR = new GroupPrimitive(
+const CURSOR = style(
   new LinePrimitive(
     Point.point(WIDTH / 2, TIMELINE_TOP),
     Point.point(WIDTH / 2, TIMELINE_TOP + HEIGHT / 4)
@@ -201,10 +201,10 @@ class SoundScene {
       const timeline = RENDERED_TIMELINES[this.selected_melody];
       const shifted = new GroupPrimitive(timeline, { transform });
 
-      return new GroupPrimitive([...primitives, shifted, CURSOR]);
+      return group([...primitives, shifted, CURSOR]);
     }
 
-    return new GroupPrimitive(primitives);
+    return group(primitives);
   }
 
   update() {}

--- a/lab/lablib/MuteButton.js
+++ b/lab/lablib/MuteButton.js
@@ -6,6 +6,7 @@ import {
   LinePrimitive,
   PolygonPrimitive,
 } from "../../sketchlib/rendering/primitives.js";
+import { group, style } from "../../sketchlib/rendering/shorthand.js";
 import { Style } from "../../sketchlib/Style.js";
 import { Rectangle } from "./Rectangle.js";
 import { ToggleButton, ToggleState } from "./ToggleButton.js";
@@ -49,9 +50,10 @@ const SPEAKER_BASE = new PolygonPrimitive([
   ),
 ]);
 
-const SPEAKER = style([SPEAKER_BASE, SPEAKER_CONE], {
-  style: new Style({ stroke: Color.WHITE }),
-});
+const SPEAKER = style(
+  [SPEAKER_BASE, SPEAKER_CONE],
+  new Style({ stroke: Color.WHITE })
+);
 
 const SPEAKER_SLASH = style(
   new LinePrimitive(
@@ -60,9 +62,9 @@ const SPEAKER_SLASH = style(
       Point.direction((3 * SOUND_TOGGLE_SIZE) / 4 - 2, SOUND_TOGGLE_SIZE - 2)
     )
   ),
-  { style: new Style({ stroke: Color.RED }) }
+  new Style({ stroke: Color.RED })
 );
-const GROUP_MUTED = group([SPEAKER, SPEAKER_SLASH]);
+const GROUP_MUTED = group(SPEAKER, SPEAKER_SLASH);
 const GROUP_UNMUTED = SPEAKER;
 
 export class MuteButton {

--- a/lab/lablib/MuteButton.js
+++ b/lab/lablib/MuteButton.js
@@ -49,11 +49,11 @@ const SPEAKER_BASE = new PolygonPrimitive([
   ),
 ]);
 
-const SPEAKER = new GroupPrimitive([SPEAKER_BASE, SPEAKER_CONE], {
+const SPEAKER = style([SPEAKER_BASE, SPEAKER_CONE], {
   style: new Style({ stroke: Color.WHITE }),
 });
 
-const SPEAKER_SLASH = new GroupPrimitive(
+const SPEAKER_SLASH = style(
   new LinePrimitive(
     SOUND_TOGGLE_CORNER.add(Point.direction(2, 2)),
     SOUND_TOGGLE_CORNER.add(
@@ -62,7 +62,7 @@ const SPEAKER_SLASH = new GroupPrimitive(
   ),
   { style: new Style({ stroke: Color.RED }) }
 );
-const GROUP_MUTED = new GroupPrimitive([SPEAKER, SPEAKER_SLASH]);
+const GROUP_MUTED = group([SPEAKER, SPEAKER_SLASH]);
 const GROUP_UNMUTED = SPEAKER;
 
 export class MuteButton {

--- a/lab/lablib/PlayButton.js
+++ b/lab/lablib/PlayButton.js
@@ -13,7 +13,7 @@ const PLAY_TRIANGLE = new PolygonPrimitive([
   Point.point(WIDTH / 2 - TRIANGLE_WIDTH / 2, HEIGHT / 2 + TRIANGLE_WIDTH / 2),
   Point.point(WIDTH / 2 + TRIANGLE_WIDTH / 2, HEIGHT / 2),
 ]);
-const PLAY_GROUP = new GroupPrimitive(PLAY_TRIANGLE, {
+const PLAY_GROUP = style(PLAY_TRIANGLE, {
   style: new Style({ stroke: Color.WHITE }),
 });
 
@@ -28,7 +28,7 @@ export class PlayButton {
 
   render() {
     const button_back = this.button.debug_render();
-    return new GroupPrimitive([button_back, PLAY_GROUP]);
+    return group([button_back, PLAY_GROUP]);
   }
 
   mouse_pressed(input) {

--- a/lab/lablib/PlayButton.js
+++ b/lab/lablib/PlayButton.js
@@ -3,6 +3,7 @@ import { Color } from "../../sketchlib/Color.js";
 import { HEIGHT, WIDTH } from "../../sketchlib/dimensions.js";
 import { GroupPrimitive } from "../../sketchlib/rendering/GroupPrimitive.js";
 import { PolygonPrimitive } from "../../sketchlib/rendering/primitives.js";
+import { group, style } from "../../sketchlib/rendering/shorthand.js";
 import { Style } from "../../sketchlib/Style.js";
 import { SCREEN_RECT } from "./Rectangle.js";
 import { TouchButton } from "./TouchButton.js";
@@ -13,9 +14,7 @@ const PLAY_TRIANGLE = new PolygonPrimitive([
   Point.point(WIDTH / 2 - TRIANGLE_WIDTH / 2, HEIGHT / 2 + TRIANGLE_WIDTH / 2),
   Point.point(WIDTH / 2 + TRIANGLE_WIDTH / 2, HEIGHT / 2),
 ]);
-const PLAY_GROUP = style(PLAY_TRIANGLE, {
-  style: new Style({ stroke: Color.WHITE }),
-});
+const PLAY_GROUP = style(PLAY_TRIANGLE, new Style({ stroke: Color.WHITE }));
 
 export class PlayButton {
   constructor() {
@@ -28,7 +27,7 @@ export class PlayButton {
 
   render() {
     const button_back = this.button.debug_render();
-    return group([button_back, PLAY_GROUP]);
+    return group(button_back, PLAY_GROUP);
   }
 
   mouse_pressed(input) {

--- a/lab/lablib/ToggleButton.js
+++ b/lab/lablib/ToggleButton.js
@@ -66,7 +66,7 @@ export class ToggleButton {
         ? Style.DEFAULT_FILL
         : new Style({ fill: Color.MAGENTA });
 
-    return new GroupPrimitive(rect, { style });
+    return style(rect, { style });
   }
 
   /**

--- a/lab/lablib/TouchButton.js
+++ b/lab/lablib/TouchButton.js
@@ -2,6 +2,7 @@ import { Point } from "../../pga2d/objects.js";
 import { Color } from "../../sketchlib/Color.js";
 import { GroupPrimitive } from "../../sketchlib/rendering/GroupPrimitive.js";
 import { RectPrimitive } from "../../sketchlib/rendering/primitives.js";
+import { style } from "../../sketchlib/rendering/shorthand.js";
 import { Style } from "../../sketchlib/Style.js";
 import { Rectangle } from "./Rectangle.js";
 
@@ -54,9 +55,8 @@ export class TouchButton {
 
   debug_render() {
     const rect = new RectPrimitive(this.rect.position, this.rect.dimensions);
-    const style = this.get_debug_style();
 
-    return style(rect, { style });
+    return style(rect, this.get_debug_style());
   }
 
   /**

--- a/lab/lablib/TouchButton.js
+++ b/lab/lablib/TouchButton.js
@@ -56,7 +56,7 @@ export class TouchButton {
     const rect = new RectPrimitive(this.rect.position, this.rect.dimensions);
     const style = this.get_debug_style();
 
-    return new GroupPrimitive(rect, { style });
+    return style(rect, { style });
   }
 
   /**

--- a/lab/lablib/TouchDPad.js
+++ b/lab/lablib/TouchDPad.js
@@ -187,12 +187,12 @@ export class TouchDPad {
     const STYLE_IDLE = Style.DEFAULT_STROKE.with_width(2);
     const STYLE_PRESSED = Style.DEFAULT_STROKE_FILL.with_width(2);
 
-    const idle_group = new GroupPrimitive(idle_buttons, { style: STYLE_IDLE });
-    const pressed_group = new GroupPrimitive(pressed_buttons, {
+    const idle_group = style(idle_buttons, { style: STYLE_IDLE });
+    const pressed_group = style(pressed_buttons, {
       style: STYLE_PRESSED,
     });
 
-    return new GroupPrimitive([idle_group, pressed_group]);
+    return group([idle_group, pressed_group]);
   }
 
   debug_render() {
@@ -220,7 +220,7 @@ export class TouchDPad {
       center.add(digital_offset)
     );
 
-    return new GroupPrimitive([boundary, analog_arrow, digital_arrow], {
+    return style([boundary, analog_arrow, digital_arrow], {
       style: Style.DEFAULT_STROKE,
     });
   }

--- a/lab/lablib/TouchDPad.js
+++ b/lab/lablib/TouchDPad.js
@@ -6,6 +6,7 @@ import {
   RectPrimitive,
   VectorPrimitive,
 } from "../../sketchlib/rendering/primitives.js";
+import { group, style } from "../../sketchlib/rendering/shorthand.js";
 import { Style } from "../../sketchlib/Style.js";
 import { DirectionInput } from "./DirectionInput.js";
 import { MouseInCanvas, MouseInput } from "./MouseInput.js";
@@ -187,12 +188,10 @@ export class TouchDPad {
     const STYLE_IDLE = Style.DEFAULT_STROKE.with_width(2);
     const STYLE_PRESSED = Style.DEFAULT_STROKE_FILL.with_width(2);
 
-    const idle_group = style(idle_buttons, { style: STYLE_IDLE });
-    const pressed_group = style(pressed_buttons, {
-      style: STYLE_PRESSED,
-    });
+    const idle_group = style(idle_buttons, STYLE_IDLE);
+    const pressed_group = style(pressed_buttons, STYLE_PRESSED);
 
-    return group([idle_group, pressed_group]);
+    return group(idle_group, pressed_group);
   }
 
   debug_render() {
@@ -220,8 +219,6 @@ export class TouchDPad {
       center.add(digital_offset)
     );
 
-    return style([boundary, analog_arrow, digital_arrow], {
-      style: Style.DEFAULT_STROKE,
-    });
+    return style([boundary, analog_arrow, digital_arrow], Style.DEFAULT_STROKE);
   }
 }

--- a/lab/lablib/music/render_score.js
+++ b/lab/lablib/music/render_score.js
@@ -1,6 +1,7 @@
 import { Point } from "../../../pga2d/objects.js";
 import { GroupPrimitive } from "../../../sketchlib/rendering/GroupPrimitive.js";
 import { RectPrimitive } from "../../../sketchlib/rendering/primitives.js";
+import { group, style } from "../../../sketchlib/rendering/shorthand.js";
 import { Style } from "../../../sketchlib/Style.js";
 import { count_voices } from "./count_voices.js";
 import { Harmony, Score } from "./Score.js";
@@ -56,7 +57,7 @@ export function render_timeline(offset, timeline, measure_dimensions) {
       const child_width = child.duration.real * measure_dimensions.x;
       child_offset = child_offset.add(Point.direction(child_width, 0));
     }
-    return group(child_blocks.filter((x) => x !== undefined));
+    return group(...child_blocks.filter((x) => x !== undefined));
   }
 
   if (timeline instanceof Harmony) {
@@ -74,7 +75,7 @@ export function render_timeline(offset, timeline, measure_dimensions) {
       const child_height = count_voices(child) * measure_dimensions.y;
       child_offset = child_offset.add(Point.direction(0, child_height));
     }
-    return group(child_blocks.filter((x) => x !== undefined));
+    return group(...child_blocks.filter((x) => x !== undefined));
   }
 
   // For now cycles, loops and individual intervals are rendered as a single
@@ -105,11 +106,11 @@ export function render_score(offset, score, measure_dimensions, styles) {
       part,
       measure_dimensions
     );
-    const part_group = style(rendered, { style: styles[i] });
+    const part_group = style(rendered, styles[i]);
     parts.push(part_group);
 
     voices_so_far += count_voices(part);
   }
 
-  return group(parts);
+  return group(...parts);
 }

--- a/lab/lablib/music/render_score.js
+++ b/lab/lablib/music/render_score.js
@@ -56,7 +56,7 @@ export function render_timeline(offset, timeline, measure_dimensions) {
       const child_width = child.duration.real * measure_dimensions.x;
       child_offset = child_offset.add(Point.direction(child_width, 0));
     }
-    return new GroupPrimitive(child_blocks.filter((x) => x !== undefined));
+    return group(child_blocks.filter((x) => x !== undefined));
   }
 
   if (timeline instanceof Harmony) {
@@ -74,7 +74,7 @@ export function render_timeline(offset, timeline, measure_dimensions) {
       const child_height = count_voices(child) * measure_dimensions.y;
       child_offset = child_offset.add(Point.direction(0, child_height));
     }
-    return new GroupPrimitive(child_blocks.filter((x) => x !== undefined));
+    return group(child_blocks.filter((x) => x !== undefined));
   }
 
   // For now cycles, loops and individual intervals are rendered as a single
@@ -105,11 +105,11 @@ export function render_score(offset, score, measure_dimensions, styles) {
       part,
       measure_dimensions
     );
-    const part_group = new GroupPrimitive(rendered, { style: styles[i] });
+    const part_group = style(rendered, { style: styles[i] });
     parts.push(part_group);
 
     voices_so_far += count_voices(part);
   }
 
-  return new GroupPrimitive(parts);
+  return group(parts);
 }

--- a/sketchlib/AnimationChain.js
+++ b/sketchlib/AnimationChain.js
@@ -155,12 +155,12 @@ export class AnimationChain {
     for (let i = 0; i < lines.length; i++) {
       lines[i] = new LinePrimitive(positions[i], positions[i + 1]);
     }
-    const spine_group = new GroupPrimitive(lines, { style: SPINE_STYLE });
+    const spine_group = style(lines, { style: SPINE_STYLE });
 
     const centers = positions.map((x) => new PointPrimitive(x));
-    const centers_group = new GroupPrimitive(centers, { style: CENTER_STYLE });
+    const centers_group = style(centers, { style: CENTER_STYLE });
 
-    return new GroupPrimitive([spine_group, centers_group]);
+    return group([spine_group, centers_group]);
   }
 
   /**

--- a/sketchlib/AnimationChain.js
+++ b/sketchlib/AnimationChain.js
@@ -3,6 +3,7 @@ import { Motor } from "../pga2d/versors.js";
 import { Color } from "./Color.js";
 import { GroupPrimitive } from "./rendering/GroupPrimitive.js";
 import { LinePrimitive, PointPrimitive } from "./rendering/primitives.js";
+import { group, style } from "./rendering/shorthand.js";
 import { Style } from "./Style.js";
 
 const SPINE_STYLE = Style.DEFAULT_STROKE;
@@ -155,12 +156,12 @@ export class AnimationChain {
     for (let i = 0; i < lines.length; i++) {
       lines[i] = new LinePrimitive(positions[i], positions[i + 1]);
     }
-    const spine_group = style(lines, { style: SPINE_STYLE });
+    const spine_group = style(lines, SPINE_STYLE);
 
     const centers = positions.map((x) => new PointPrimitive(x));
-    const centers_group = style(centers, { style: CENTER_STYLE });
+    const centers_group = style(centers, CENTER_STYLE);
 
-    return group([spine_group, centers_group]);
+    return group(spine_group, centers_group);
   }
 
   /**

--- a/sketchlib/rendering/shorthand.js
+++ b/sketchlib/rendering/shorthand.js
@@ -24,7 +24,7 @@ export function group(...primitives) {
  */
 export function style(primitives, style) {
   return new GroupPrimitive(primitives, {
-    style: style,
+    style,
   });
 }
 
@@ -36,6 +36,6 @@ export function style(primitives, style) {
  */
 export function xform(primitives, transform) {
   return new GroupPrimitive(primitives, {
-    transform: transform,
+    transform,
   });
 }

--- a/sketchlib/rendering/shorthand.js
+++ b/sketchlib/rendering/shorthand.js
@@ -19,12 +19,12 @@ export function group(...primitives) {
 /**
  * Apply a style to one or more primitives, creating a group
  * @param {Primitive | Primitive[]} primitives The primitives
- * @param {Style} style The style to apply to all the primitives
+ * @param {Style} style_descriptor The style to apply to all the primitives
  * @returns {GroupPrimitive} The grouped and styled primitives
  */
-export function style(primitives, style) {
+export function style(primitives, style_descriptor) {
   return new GroupPrimitive(primitives, {
-    style,
+    style: style_descriptor,
   });
 }
 

--- a/sketchlib/rendering/shorthand.js
+++ b/sketchlib/rendering/shorthand.js
@@ -1,0 +1,41 @@
+import { Style } from "../Style.js";
+import { GroupPrimitive } from "./GroupPrimitive.js";
+import { Transform } from "./Transform.js";
+
+/**
+ * @typedef {import("./primitives").SimplePrimitive | GroupPrimitive} Primitive
+ */
+
+/**
+ * Shorthand for creating a GroupPrimitive that just groups primitives with
+ * no styling/transformations
+ * @param  {...Primitive} primitives
+ * @returns
+ */
+export function group(...primitives) {
+  return new GroupPrimitive(primitives);
+}
+
+/**
+ * Apply a style to one or more primitives, creating a group
+ * @param {Primitive | Primitive[]} primitives The primitives
+ * @param {Style} style The style to apply to all the primitives
+ * @returns {GroupPrimitive} The grouped and styled primitives
+ */
+export function style(primitives, style) {
+  return new GroupPrimitive(primitives, {
+    style: style,
+  });
+}
+
+/**
+ * Apply a transformation to one or more primitives, creating a group
+ * @param {Primitive | Primitive[]} primitives The primitive(s) to group
+ * @param {Transform} transform The transform to apply
+ * @returns {GroupPrimitive} The transformed group of primitives
+ */
+export function xform(primitives, transform) {
+  return new GroupPrimitive(primitives, {
+    transform: transform,
+  });
+}


### PR DESCRIPTION
This PR refactors the code. `new GroupPrimitive(primitives, options)` was getting unweildy. This PR

- adds `group(...primitives)` to create a group for grouping only
- adds `style(primitives, style)` to create a group and apply a style
- adds `xform(primitives, transform)` to create a group and apply a 2D transformation.

The first two are already quite common operations, and the third one will likely be common in time.