### PR TITLE
Tweak the Piano to not throw errors

### DIFF
--- a/lab/SoundTest/Piano.js
+++ b/lab/SoundTest/Piano.js
@@ -199,7 +199,7 @@ export class Piano {
       octave < this.octave_start ||
       octave >= this.octave_start + this.num_octaves
     ) {
-      console.warn("Triggering out-of-range note");
+      console.warn("Triggering out-of-range note", octave);
       return;
     }
 
@@ -221,7 +221,7 @@ export class Piano {
       octave < this.octave_start ||
       octave >= this.octave_start + this.num_octaves
     ) {
-      console.warn("Releasing out-of-range note");
+      console.warn("Releasing out-of-range note", midi_note);
       return;
     }
 
@@ -229,8 +229,10 @@ export class Piano {
     this.key_presses[midi_note]--;
 
     if (this.key_presses[midi_note] < 0) {
-      throw new Error(`more releases than triggers for note ${midi_note}!`);
-    } else if (this.key_presses[midi_note] === 0) {
+      console.warn("more releases than triggers for note", midi_note);
+    }
+
+    if (this.key_presses[midi_note] <= 0) {
       // Only release the note if duplicates have been resolved
       const pitch = MidiPitch.get_pitch_class(midi_note);
       this.octave_pianos[octave - this.octave_start].set_key(pitch, false);

--- a/lab/SoundTest/SoundTest.js
+++ b/lab/SoundTest/SoundTest.js
@@ -166,7 +166,7 @@ class SoundScene {
     this.piano = new Piano(
       new Rectangle(Point.point(0, 300), Point.direction(500, 300 / 3)),
       3,
-      3
+      4
     );
     this.spiral_burst = new SpiralBurst();
 


### PR DESCRIPTION
This PR:

- Changes the errors for too many release events into logged warnings to avoid noise for now
- Also adds an octave to the piano in `SoundTest`, I was getting warnings that the highest notes for one score were a little out of range.