### PR TITLE
Add a function for flattening timelines

### DIFF
--- a/lab/lablib/music/Timeline.js
+++ b/lab/lablib/music/Timeline.js
@@ -24,6 +24,14 @@ export class Gap {
   map() {
     return this;
   }
+
+  /**
+   * Return true if the duration is 0
+   * @return {boolean}
+   */
+  get is_empty() {
+    return this.duration.equals(Rational.ZERO);
+  }
 }
 Gap.ZERO = Object.freeze(new Gap(Rational.ZERO));
 

--- a/lab/lablib/music/flatten_timeline.js
+++ b/lab/lablib/music/flatten_timeline.js
@@ -27,7 +27,10 @@ function flatten_sequential(seq) {
       flat_child = flatten_parallel(child);
     }
 
-    if (flat_child instanceof Sequential) {
+    if (flat_child instanceof Gap && flat_child.is_empty) {
+      // filter out zero gaps
+      continue;
+    } else if (flat_child instanceof Sequential) {
       flattened.push(...flat_child.children);
     } else {
       flattened.push(flat_child);
@@ -65,7 +68,10 @@ function flatten_parallel(par) {
       flat_child = flatten_sequential(child);
     }
 
-    if (flat_child instanceof Parallel) {
+    if (flat_child instanceof Gap && flat_child.is_empty) {
+      // Filter out zero gaps
+      continue;
+    } else if (flat_child instanceof Parallel) {
       flattened.push(...flat_child.children);
     } else {
       flattened.push(flat_child);

--- a/lab/lablib/music/flatten_timeline.test.js
+++ b/lab/lablib/music/flatten_timeline.test.js
@@ -52,6 +52,30 @@ describe("flatten_timeline", () => {
     expect(result).toBe(interval);
   });
 
+  it("with Sequential containing only zero gaps returns zero gap", () => {
+    const seq = new Sequential(Gap.ZERO, Gap.ZERO);
+
+    const result = flatten_timeline(seq);
+
+    expect(result).toBe(Gap.ZERO);
+  });
+
+  it("with Sequential with zero gaps filters out gaps", () => {
+    const interval = stub_interval(1, N4);
+    const seq = new Sequential(
+      interval,
+      Gap.ZERO,
+      interval,
+      interval,
+      Gap.ZERO
+    );
+
+    const result = flatten_timeline(seq);
+
+    const expected = new Sequential(interval, interval, interval);
+    expect(result).toStrictEqual(expected);
+  });
+
   it("with nested Sequentials returns flattened Sequential", () => {
     const interval1 = stub_interval(1, N4);
     const interval2 = stub_interval(2, N2);
@@ -120,6 +144,24 @@ describe("flatten_timeline", () => {
       interval1
     );
 
+    expect(result).toStrictEqual(expected);
+  });
+
+  it("with Parallel containing only zero gaps returns zero gap", () => {
+    const seq = new Parallel(Gap.ZERO, Gap.ZERO);
+
+    const result = flatten_timeline(seq);
+
+    expect(result).toBe(Gap.ZERO);
+  });
+
+  it("with Parallel with zero gaps filters out gaps", () => {
+    const interval = stub_interval(1, N4);
+    const seq = new Parallel(interval, Gap.ZERO, interval, interval, Gap.ZERO);
+
+    const result = flatten_timeline(seq);
+
+    const expected = new Parallel(interval, interval, interval);
     expect(result).toStrictEqual(expected);
   });
 
@@ -205,5 +247,20 @@ describe("flatten_timeline", () => {
       interval1
     );
     expect(result).toStrictEqual(expected);
+  });
+
+  it("flattens complex empty timeline to zero gap", () => {
+    const whole_lot_of_nothing = new Sequential(
+      new Sequential(),
+      new Parallel(new Sequential(), new Sequential(Gap.ZERO)),
+      Gap.ZERO,
+      new Sequential(new Sequential()),
+      new Parallel(new Sequential(), Gap.ZERO),
+      Gap.ZERO
+    );
+
+    const result = flatten_timeline(whole_lot_of_nothing);
+
+    expect(result).toBe(Gap.ZERO);
   });
 });


### PR DESCRIPTION
I want to break #74 into several smaller PRs, it's gotten too big. 

When writing unit tests for it, I found it would be helpful to have a `flatten()` function that flattens heavily-nested scores. This way unit tests can be written without having to worry about redundant nesting that algorithms sometimes create.