### PR TITLE
AnimatedTangle; Use consistent theme colors

### DIFF
--- a/lab/AnimatedTangle/AnimatedTangle.js
+++ b/lab/AnimatedTangle/AnimatedTangle.js
@@ -17,7 +17,7 @@ import { GEODE } from "./patterns/geode.js";
 import { LANDSCAPE } from "./patterns/landscape.js";
 import { EYE } from "./patterns/peek.js";
 import { make_stripes } from "./patterns/stripes.js";
-import { PALETTE_CORAL, PALETTE_NAVY, PALETTE_SKY } from "./theme_colors.js";
+import { PALETTE_CORAL, PALETTE_NAVY, Values } from "./theme_colors.js";
 
 /**
  * Shorthand for making arrays of points
@@ -56,7 +56,7 @@ const PANEL_STRIPES = new PolygonPrimitive(
 );
 
 const PANEL_STYLE = new Style({
-  stroke: PALETTE_NAVY[4].to_srgb(),
+  stroke: PALETTE_NAVY[Values.Light].to_srgb(),
   width: 10,
 });
 
@@ -91,7 +91,7 @@ const QUARTER_PEEK = new RectPrimitive(
 );
 
 const STYLE_QUARTERS = new Style({
-  stroke: PALETTE_CORAL[4].to_srgb(),
+  stroke: PALETTE_CORAL[Values.Light].to_srgb(),
   width: 4,
 });
 const QUARTERS = new VectorTangle([
@@ -115,7 +115,7 @@ const TANGLE = new VectorTangle(
 
 const STYLE_BACKGROUND_STRIPES = new Style({
   // navy blue
-  stroke: PALETTE_NAVY[0].to_srgb(),
+  stroke: PALETTE_NAVY[Values.Dark].to_srgb(),
   width: 15,
 });
 const BACKGROUND_STRIPES = style(

--- a/lab/AnimatedTangle/patterns/circle_fan.js
+++ b/lab/AnimatedTangle/patterns/circle_fan.js
@@ -15,7 +15,12 @@ import { PolygonPrimitive } from "../../../sketchlib/primitives/PolygonPrimitive
 import { Motor } from "../../../pga2d/versors.js";
 import { Transform } from "../../../sketchlib/primitives/Transform.js";
 import { GroupPrimitive } from "../../../sketchlib/primitives/GroupPrimitive.js";
-import { PALETTE_CORAL, PALETTE_NAVY, PALETTE_SKY } from "../theme_colors.js";
+import {
+  PALETTE_CORAL,
+  PALETTE_NAVY,
+  PALETTE_SKY,
+  Values,
+} from "../theme_colors.js";
 import { Ease } from "../../../sketchlib/Ease.js";
 
 const CENTER = new Point(500, 300);
@@ -24,14 +29,14 @@ const MAX_RADII = [5, 4, 3, 2, 1].map((x) => x * BAND_THICKNESS);
 const CIRCLE_COUNT = MAX_RADII.length;
 
 const STYLE_CIRCLES = new Style({
-  fill: PALETTE_NAVY[3].to_srgb(),
-  stroke: PALETTE_SKY[4].to_srgb(),
+  fill: PALETTE_NAVY[Values.MedLight].to_srgb(),
+  stroke: PALETTE_SKY[Values.Light].to_srgb(),
   width: 5,
 });
 
 const STYLE_DIAMONDS = new Style({
-  fill: PALETTE_CORAL[3].to_srgb(),
-  stroke: PALETTE_NAVY[2].to_srgb(),
+  fill: PALETTE_CORAL[Values.MedLight].to_srgb(),
+  stroke: PALETTE_NAVY[Values.Medium].to_srgb(),
   width: 2,
 });
 

--- a/lab/AnimatedTangle/patterns/coral.js
+++ b/lab/AnimatedTangle/patterns/coral.js
@@ -7,14 +7,14 @@ import { Style } from "../../../sketchlib/Style.js";
 import { CoralNode, CoralTree } from "../CoralTree.js";
 import { AnimatedStripes } from "./stripes.js";
 import { Hinge } from "../Hinge.js";
-import { PALETTE_CORAL, PALETTE_SKY } from "../theme_colors.js";
+import { PALETTE_CORAL, PALETTE_SKY, Values } from "../theme_colors.js";
 
 const RADIUS_BIG = 25;
 const RADIUS_SMALL = RADIUS_BIG / 2;
 
 const STYLE_CORAL = new Style({
-  fill: PALETTE_CORAL.at(-1).to_srgb(),
-  stroke: PALETTE_CORAL.at(-2).adjust_lightness(-0.2).to_srgb(),
+  fill: PALETTE_CORAL[Values.Light].to_srgb(),
+  stroke: PALETTE_CORAL[Values.MedDark].to_srgb(),
   width: 4,
 });
 
@@ -26,7 +26,7 @@ export const CORAL_STRIPES = new AnimatedStripes(
 );
 
 const STYLE_STRIPES = new Style({
-  stroke: PALETTE_SKY[3].to_srgb(),
+  stroke: PALETTE_SKY[Values.MedLight].to_srgb(),
   width: 4,
 });
 

--- a/lab/AnimatedTangle/patterns/geode.js
+++ b/lab/AnimatedTangle/patterns/geode.js
@@ -11,16 +11,16 @@ import { group, style } from "../../../sketchlib/primitives/shorthand.js";
 import { Style } from "../../../sketchlib/Style.js";
 import { make_stripes } from "./stripes.js";
 import { ParamCurve } from "../../lablib/animation/ParamCurve.js";
-import { PALETTE_CORAL, PALETTE_ROCK } from "../theme_colors.js";
+import { PALETTE_CORAL, PALETTE_ROCK, Values } from "../theme_colors.js";
 import { Oklch } from "../../lablib/Oklch.js";
 import { Random } from "../../../sketchlib/random.js";
 
 const STYLE_ROCK1 = new Style({
-  stroke: PALETTE_ROCK[1].to_srgb(),
+  stroke: PALETTE_ROCK[Values.MedDark].to_srgb(),
   width: 4,
 });
 const STYLE_ROCK2 = new Style({
-  stroke: PALETTE_ROCK[2].to_srgb(),
+  stroke: PALETTE_ROCK[Values.Medium].to_srgb(),
   width: 4,
 });
 
@@ -42,7 +42,7 @@ const ROCK_STRIPES2 = make_stripes(
 );
 
 const STYLE_INSIDE_GEODE = new Style({
-  fill: PALETTE_ROCK[0].to_srgb(),
+  fill: PALETTE_ROCK[Values.Dark].to_srgb(),
 });
 
 export class Geode {
@@ -115,7 +115,11 @@ const GEODE_BOUNDARY = new PolygonPrimitive(
 const WIDTHS = [8, 7, 6, 5, 4, 3, 2, 1].map((x) => 8 * x);
 
 const PALETTE_AGATE = Random.shuffle(
-  Oklch.gradient(PALETTE_CORAL[0], PALETTE_CORAL.at(-1), WIDTHS.length)
+  Oklch.gradient(
+    PALETTE_CORAL[Values.Dark],
+    PALETTE_CORAL[Values.Light],
+    WIDTHS.length
+  )
 );
 
 /**

--- a/lab/AnimatedTangle/patterns/landscape.js
+++ b/lab/AnimatedTangle/patterns/landscape.js
@@ -12,10 +12,10 @@ import {
 } from "../../../sketchlib/primitives/shorthand.js";
 import { Transform } from "../../../sketchlib/primitives/Transform.js";
 import { Style } from "../../../sketchlib/Style.js";
-import { PALETTE_ROCK } from "../theme_colors.js";
+import { PALETTE_ROCK, Values } from "../theme_colors.js";
 
 const STYLE_MOUNTAINS = new Style({
-  fill: PALETTE_ROCK[1].to_srgb(),
+  fill: PALETTE_ROCK[Values.MedDark].to_srgb(),
 });
 
 class Landscape {

--- a/lab/AnimatedTangle/theme_colors.js
+++ b/lab/AnimatedTangle/theme_colors.js
@@ -23,3 +23,15 @@ export const PALETTE_ROCK = Oklch.gradient(
   new Oklch(0.7, 0, 0),
   5
 );
+
+/**
+ * Color values for 5-step palettes
+ * @enum {number}
+ */
+export const Values = {
+  Dark: 0,
+  MedDark: 1,
+  Medium: 2,
+  MedLight: 3,
+  Light: 4,
+};


### PR DESCRIPTION
For AnimatedTangle, the loud 3-bit colors were temporary and clash. I'm changing it to use a more restricted color palette -- various shades of blue, coral, and grey

<img width="500" height="700" alt="image" src="https://github.com/user-attachments/assets/17dfec9d-3217-4690-a7ed-b5d9055c3067" />
