### PR TITLE
Debugging very nested score creation in midi_to_score

### DIFF
--- a/sketchlib/music/AbsTimelineOps.js
+++ b/sketchlib/music/AbsTimelineOps.js
@@ -16,16 +16,26 @@ import { Gap, Parallel, Sequential } from "./Timeline.js";
  * Concat timelines, adding an AbsGap in between if needed
  * @template T
  * @param {AbsTimeline<T>} a First timeline
- * @param {AbsTimeline<T>} b second timeline
+ * @param {AbsInterval<T>} b second timeline
  * @returns {AbsSequential<T>} The concatenated timeline
  */
 function concat_timelines(a, b) {
-  if (a.end_time.equals(b.start_time)) {
-    return new AbsSequential(a, b);
+  const children = [];
+
+  // If the left timeline is a sequential, unpack it
+  // to avoid unnecessary nesting
+  if (a instanceof AbsSequential) {
+    children.push(...a.children);
+  } else {
+    children.push(a);
   }
 
-  const gap = new AbsGap(a.end_time, b.start_time);
-  return new AbsSequential(a, gap, b);
+  if (!a.end_time.equals(b.start_time)) {
+    const gap = new AbsGap(a.end_time, b.start_time);
+    children.push(gap);
+  }
+
+  return new AbsSequential(...children, b);
 }
 
 /**

--- a/sketchlib/music/AbsTimelineOps.test.js
+++ b/sketchlib/music/AbsTimelineOps.test.js
@@ -117,6 +117,31 @@ describe("AbsTimelineOps", () => {
       expect(result).toEqual(expected);
     });
 
+    it("with many intervals that meet exactly returns AbsSequential", () => {
+      const intervals = [
+        new AbsInterval(1, Rational.ONE, new Rational(2)),
+        new AbsInterval(2, new Rational(2), new Rational(3)),
+        new AbsInterval(3, new Rational(3), new Rational(4)),
+        new AbsInterval(4, new Rational(4), new Rational(5)),
+        new AbsInterval(5, new Rational(5), new Rational(6)),
+        new AbsInterval(6, new Rational(6), new Rational(7)),
+        new AbsInterval(7, new Rational(7), new Rational(8)),
+      ];
+
+      const result = AbsTimelineOps.from_intervals(intervals);
+
+      const expected = new AbsSequential(
+        new AbsInterval(1, Rational.ONE, new Rational(2)),
+        new AbsInterval(2, new Rational(2), new Rational(3)),
+        new AbsInterval(3, new Rational(3), new Rational(4)),
+        new AbsInterval(4, new Rational(4), new Rational(5)),
+        new AbsInterval(5, new Rational(5), new Rational(6)),
+        new AbsInterval(6, new Rational(6), new Rational(7)),
+        new AbsInterval(7, new Rational(7), new Rational(8)),
+      );
+      expect(result).toEqual(expected);
+    });
+
     it("with two intervals that are out of order returns AbsSequential in sorted order", () => {
       const intervals = [
         new AbsInterval(2, new Rational(2), new Rational(3)),


### PR DESCRIPTION
So far I just have a unit test that reproduces #262. too late in the day to think about a fix