### PR TITLE
AnimatedTangle/Traffic: Update the rectangles directly to avoid lots of transformations

### DIFF
--- a/AnimatedTangle/patterns/traffic.js
+++ b/AnimatedTangle/patterns/traffic.js
@@ -1,27 +1,16 @@
 import { Direction } from "../../sketchlib/pga2d/Direction.js";
 import { Point } from "../../sketchlib/pga2d/Point.js";
 import { Ease } from "../../sketchlib/Ease.js";
-import { Circle } from "../../sketchlib/primitives/Circle.js";
-import { GroupPrimitive } from "../../sketchlib/primitives/GroupPrimitive.js";
 import { RectPrimitive } from "../../sketchlib/primitives/RectPrimitive.js";
-import { group, style, xform } from "../../sketchlib/primitives/shorthand.js";
-import { Transform } from "../../sketchlib/primitives/Transform.js";
+import { group } from "../../sketchlib/primitives/shorthand.js";
 import { Style } from "../../sketchlib/Style.js";
 import { Animated } from "../../sketchlib/animation/Animated.js";
 import { AnimationGroup } from "../../sketchlib/animation/AnimationGroup.js";
 import { LoopCurve } from "../../sketchlib/animation/LoopCurve.js";
-import {
-  make_param,
-  ParamCurve,
-} from "../../sketchlib/animation/ParamCurve.js";
+import { make_param } from "../../sketchlib/animation/ParamCurve.js";
 import { Sequential } from "../../sketchlib/music/Timeline.js";
 import { Rational } from "../../sketchlib/Rational.js";
-import {
-  PALETTE_CORAL,
-  PALETTE_NAVY,
-  PALETTE_SKY,
-  Values,
-} from "../theme_colors.js";
+import { PALETTE_CORAL, Values } from "../theme_colors.js";
 import {
   LayerPrimitive,
   RenderLayers,
@@ -40,14 +29,12 @@ const CURVE_POSITION = LoopCurve.from_timeline(TIMELINE_POSITION);
 const PLATFORM_WIDTH = 25;
 const PLATFORM_HEIGHT = 25;
 const TOP_HEIGHT = 15;
-const PLATFORM_TOP = new RectPrimitive(
-  Point.ORIGIN,
-  new Direction(PLATFORM_WIDTH, TOP_HEIGHT),
+const DIMS_PLATFORM_TOP = new Direction(PLATFORM_WIDTH, TOP_HEIGHT);
+const DIMS_PLATFORM_SHADOW = new Direction(
+  PLATFORM_WIDTH,
+  PLATFORM_HEIGHT - TOP_HEIGHT,
 );
-const PLATFORM_SHADOW = new RectPrimitive(
-  new Point(0, TOP_HEIGHT),
-  new Direction(PLATFORM_WIDTH, PLATFORM_HEIGHT - TOP_HEIGHT),
-);
+const SHADOW_ORIGIN = new Point(0, TOP_HEIGHT);
 const STYLE_TOP = new Style({
   fill: PALETTE_CORAL[Values.MED_LIGHT],
 });
@@ -74,14 +61,25 @@ class TrafficLane {
   constructor(center_offset) {
     this.center_offset = center_offset;
 
-    this.transforms = PHASES.map((phase) => {
+    this.platform_tops = new Array(PHASES.length);
+    this.platform_shadows = new Array(PHASES.length);
+
+    PHASES.forEach((phase, i) => {
       const dx = CURVE_POSITION.value(phase);
-      return new Transform(center_offset.add(Direction.DIR_X.scale(dx)));
+      const offset = center_offset.add(Direction.DIR_X.scale(dx));
+      this.platform_tops[i] = new RectPrimitive(
+        Point.ORIGIN.add(offset),
+        DIMS_PLATFORM_TOP,
+      );
+      this.platform_shadows[i] = new RectPrimitive(
+        SHADOW_ORIGIN.add(offset),
+        DIMS_PLATFORM_SHADOW,
+      );
     });
 
     this.layers = [
-      group(...this.transforms.map((x) => xform(PLATFORM_TOP, x))),
-      group(...this.transforms.map((x) => xform(PLATFORM_SHADOW, x))),
+      group(...this.platform_tops),
+      group(...this.platform_shadows),
     ];
 
     this.primitive = group(...this.layers);
@@ -92,9 +90,11 @@ class TrafficLane {
    * @param {number} time
    */
   update(time) {
-    this.transforms.forEach((t, i) => {
-      const dx = CURVE_POSITION.value(time + PHASES[i]);
-      t.translation = this.center_offset.add(Direction.DIR_X.scale(dx));
+    PHASES.forEach((phase, i) => {
+      const dx = CURVE_POSITION.value(time + phase);
+      const offset = this.center_offset.add(Direction.DIR_X.scale(dx));
+      this.platform_tops[i].position = Point.ORIGIN.add(offset);
+      this.platform_shadows[i].position = SHADOW_ORIGIN.add(offset);
     });
   }
 }


### PR DESCRIPTION
Closes #382 

This helps for Traffic, but that's about it.

There are still a few places that use transformations, but those use PolygonPrimitive/BezierPrimitive so I can't easily replace them. 