### PR TITLE
Generate basic single-cycle waveforms

### DIFF
--- a/SoundTest/SoundTest.js
+++ b/SoundTest/SoundTest.js
@@ -49,6 +49,10 @@ import { SoundScene } from "../sketchlib/scenes/SoundScene.js";
 import { AnimationGroup } from "../sketchlib/animation/AnimationGroup.js";
 import { Primitive } from "../sketchlib/primitives/Primitive.js";
 import { download_file } from "../sketchlib/dom/download_file.js";
+import { KeywordRecognizer } from "../sketchlib/KeywordRecognizer.js";
+import { sample_single_cycle } from "../sketchlib/waveforms/sample_single_cycle.js";
+import { sine } from "../sketchlib/waveforms/basic_waves.js";
+import { encode_wav_file } from "../sketchlib/waveforms/encode_wav.js";
 
 const DEBUG_LOOP = false;
 const LOOP_START = new Rational(14 * 4);
@@ -221,6 +225,18 @@ function clear_errors() {
 function show_error(message) {
   document.getElementById("errors").innerText = message;
 }
+
+const SLASH = new KeywordRecognizer();
+
+// A4 = 440 Hz
+const SAMPLE_FREQ = 440;
+
+// /trace logs a trace of the scene for investigating performance issues.
+SLASH.register(["Slash", "KeyS", "KeyI", "KeyN", "KeyE"], () => {
+  const samples = sample_single_cycle(sine, SAMPLE_FREQ);
+  const wav_file = encode_wav_file(samples, "sine-A4.wav");
+  download_file(wav_file);
+});
 
 /**
  * Import a MIDI file from a file picker
@@ -570,10 +586,6 @@ class SoundTestAnimation {
   }
 }
 
-/**
- *
- * @param {import("p5")} p
- */
 export const sketch = (p) => {
   /** @type {PlayButtonScene | SoundScene} */
   let scene = new PlayButtonScene(SOUND);
@@ -604,4 +616,8 @@ export const sketch = (p) => {
   };
 
   MOUSE.configure_callbacks(p);
+
+  p.keyReleased = (/** @type {KeyboardEvent}*/ e) => {
+    SLASH.input(e.code);
+  };
 };

--- a/SoundTest/SoundTest.js
+++ b/SoundTest/SoundTest.js
@@ -51,7 +51,12 @@ import { Primitive } from "../sketchlib/primitives/Primitive.js";
 import { download_file } from "../sketchlib/dom/download_file.js";
 import { KeywordRecognizer } from "../sketchlib/KeywordRecognizer.js";
 import { sample_single_cycle } from "../sketchlib/waveforms/sample_single_cycle.js";
-import { sine } from "../sketchlib/waveforms/basic_waves.js";
+import {
+  sawtooth,
+  sine,
+  triangle,
+  square,
+} from "../sketchlib/waveforms/basic_waves.js";
 import { encode_wav_file } from "../sketchlib/waveforms/encode_wav.js";
 
 const DEBUG_LOOP = false;
@@ -235,6 +240,24 @@ const SAMPLE_FREQ = 440;
 SLASH.register(["Slash", "KeyS", "KeyI", "KeyN", "KeyE"], () => {
   const samples = sample_single_cycle(sine, SAMPLE_FREQ);
   const wav_file = encode_wav_file(samples, "sine-A4.wav");
+  download_file(wav_file);
+});
+
+SLASH.register(["Slash", "KeyS", "KeyA", "KeyW"], () => {
+  const samples = sample_single_cycle(sawtooth, SAMPLE_FREQ);
+  const wav_file = encode_wav_file(samples, "saw-A4.wav");
+  download_file(wav_file);
+});
+
+SLASH.register(["Slash", "KeyT", "KeyR", "KeyI"], () => {
+  const samples = sample_single_cycle(triangle, SAMPLE_FREQ);
+  const wav_file = encode_wav_file(samples, "tri-A4.wav");
+  download_file(wav_file);
+});
+
+SLASH.register(["Slash", "KeyS", "KeyQ", "KeyR"], () => {
+  const samples = sample_single_cycle(square, SAMPLE_FREQ);
+  const wav_file = encode_wav_file(samples, "square-A4.wav");
   download_file(wav_file);
 });
 

--- a/SoundTest/SoundTest.js
+++ b/SoundTest/SoundTest.js
@@ -233,31 +233,33 @@ function show_error(message) {
 
 const SLASH = new KeywordRecognizer();
 
-// A4 = 440 Hz
-const SAMPLE_FREQ = 440;
+// A4 = 440 Hz, so
+// A2 is A4/2^2 = 110
+const SAMPLE_FREQ = 110;
+const SAMPLE_NOTE = "A2";
 
 // /trace logs a trace of the scene for investigating performance issues.
 SLASH.register(["Slash", "KeyS", "KeyI", "KeyN", "KeyE"], () => {
   const samples = sample_single_cycle(sine, SAMPLE_FREQ);
-  const wav_file = encode_wav_file(samples, "sine-A4.wav");
+  const wav_file = encode_wav_file(samples, `sine-${SAMPLE_NOTE}.wav`);
   download_file(wav_file);
 });
 
 SLASH.register(["Slash", "KeyS", "KeyA", "KeyW"], () => {
   const samples = sample_single_cycle(sawtooth, SAMPLE_FREQ);
-  const wav_file = encode_wav_file(samples, "saw-A4.wav");
+  const wav_file = encode_wav_file(samples, `saw-${SAMPLE_NOTE}.wav`);
   download_file(wav_file);
 });
 
 SLASH.register(["Slash", "KeyT", "KeyR", "KeyI"], () => {
   const samples = sample_single_cycle(triangle, SAMPLE_FREQ);
-  const wav_file = encode_wav_file(samples, "tri-A4.wav");
+  const wav_file = encode_wav_file(samples, `tri-${SAMPLE_NOTE}.wav`);
   download_file(wav_file);
 });
 
 SLASH.register(["Slash", "KeyS", "KeyQ", "KeyR"], () => {
   const samples = sample_single_cycle(square, SAMPLE_FREQ);
-  const wav_file = encode_wav_file(samples, "square-A4.wav");
+  const wav_file = encode_wav_file(samples, `square-${SAMPLE_NOTE}.wav`);
   download_file(wav_file);
 });
 

--- a/sketchlib/test_helpers/expect_arrays.js
+++ b/sketchlib/test_helpers/expect_arrays.js
@@ -1,11 +1,20 @@
 import { expect } from "vitest";
 
 /**
+ * Because there doesn't seem to be a common TypedArray type?
+ * @template T
+ * @typedef {{
+ *  [i: number]: T,
+ *  length: number,
+ * }} RandomAccess
+ */
+
+/**
  * expect.toEqual() doesn't work with custom matchers, so
  * loop over the arrays ourselves.
  * @template T
- * @param {T[]} arr1 First array
- * @param {T[]} arr2 Second array
+ * @param {RandomAccess<T>} arr1 First array
+ * @param {RandomAccess<T>} arr2 Second array
  * @param {function(T, T):void} expect_func callback function that can use custom matchers
  * @example
  * expect_arrays(result, expected, (result, expected) => expect(result).toBePoint(expected))

--- a/sketchlib/waveforms/basic_waves.js
+++ b/sketchlib/waveforms/basic_waves.js
@@ -1,0 +1,52 @@
+import { mod } from "../mod.js";
+
+/**
+ *
+ * @param {number} t
+ * @returns {number}
+ */
+export function sine(t) {
+  return Math.sin(2 * Math.PI * t);
+}
+
+/**
+ *
+ * @param {number} t
+ * @returns {number}
+ */
+export function square(t) {
+  return Math.sign(sine(t));
+}
+
+/**
+ *
+ * @param {number} t
+ * @returns {number}
+ */
+export function sawtooth(t) {
+  return 1 - 2 * mod(t, 1);
+}
+
+/**
+ *
+ * @param {number} t
+ * @returns {number}
+ */
+export function triangle(t) {
+  // the math below creates a triangle wave that starts at the max value,
+  // but I want a triangle wave that starts at 0, so shift by a quarter
+  // cycle
+  const phase = 0.25;
+
+  // Start with a ramp wave from [0, 1] with period 1. The range is [0, 1]
+  const unsigned_ramp = mod(t - phase, 1);
+  // scale and shift to a range of [-1, 1]
+  const signed_ramp = 2 * unsigned_ramp - 1;
+  // applying absolute value folds the wave, producing a triangle wave
+  // between [0, 1]
+  const unsigned_triangle = Math.abs(signed_ramp);
+
+  // deja vu: we need to convert to a signed value again to get the desired
+  // range of [-1, 1]
+  return 2 * unsigned_triangle - 1;
+}

--- a/sketchlib/waveforms/basic_waves.js
+++ b/sketchlib/waveforms/basic_waves.js
@@ -1,36 +1,38 @@
 import { mod } from "../mod.js";
 
 /**
- *
- * @param {number} t
- * @returns {number}
+ * It was a sine of the times.
+ * Sine wave sin(2pi t)
+ * @param {number} t Time value in [0, 1]
+ * @returns {number} Sine value in [-1, 1]
  */
 export function sine(t) {
   return Math.sin(2 * Math.PI * t);
 }
 
 /**
- *
- * @param {number} t
- * @returns {number}
+ * Square wave, computed as sign(sin(2pi * t)).
+ * @param {number} t Time in [0, 1]
+ * @returns {number} Square wave, with a value that toggles between -1 and 1,
+ * though the value is 0 at the discontinuities
  */
 export function square(t) {
   return Math.sign(sine(t));
 }
 
 /**
- *
- * @param {number} t
- * @returns {number}
+ * Sawtooth wave
+ * @param {number} t Time value in [0, 1]
+ * @returns {number} Sawtooth value in [-1, 1]
  */
 export function sawtooth(t) {
   return 1 - 2 * mod(t, 1);
 }
 
 /**
- *
- * @param {number} t
- * @returns {number}
+ * Triangle wave. This is defined so triangle(0) = 0
+ * @param {number} t Time value in [0, 1]
+ * @returns {number} Triangle value in [-1, 1]
  */
 export function triangle(t) {
   // the math below creates a triangle wave that starts at the max value,

--- a/sketchlib/waveforms/sample_single_cycle.js
+++ b/sketchlib/waveforms/sample_single_cycle.js
@@ -1,0 +1,17 @@
+import { SAMPLE_RATE } from "./encode_wav.js";
+
+/**
+ * Create a single-cycle waveform
+ * @param {function(number): number} f Waveform to sample. It should be a function from [0, 1] to [-1, 1]
+ * @param {number} frequency Desired frequency in Hz
+ * @returns {Float32Array} A single-cycle waveform as float samples in [-1, 1]
+ */
+export function sample_single_cycle(f, frequency) {
+  const sample_count = Math.floor(SAMPLE_RATE / frequency);
+  const result = new Float32Array(sample_count);
+  for (let i = 0; i < sample_count; i++) {
+    const t = i / sample_count;
+    result[i] = f(frequency * t);
+  }
+  return result;
+}

--- a/sketchlib/waveforms/sample_single_cycle.js
+++ b/sketchlib/waveforms/sample_single_cycle.js
@@ -15,7 +15,7 @@ export function sample_single_cycle(f, frequency) {
   const result = new Float32Array(sample_count);
   for (let i = 0; i < sample_count; i++) {
     const t = i / sample_count;
-    result[i] = f(frequency * t);
+    result[i] = f(t);
   }
   return result;
 }

--- a/sketchlib/waveforms/sample_single_cycle.js
+++ b/sketchlib/waveforms/sample_single_cycle.js
@@ -3,10 +3,14 @@ import { SAMPLE_RATE } from "./encode_wav.js";
 /**
  * Create a single-cycle waveform
  * @param {function(number): number} f Waveform to sample. It should be a function from [0, 1] to [-1, 1]
- * @param {number} frequency Desired frequency in Hz
+ * @param {number} frequency Desired frequency in Hz. It must be positive
  * @returns {Float32Array} A single-cycle waveform as float samples in [-1, 1]
  */
 export function sample_single_cycle(f, frequency) {
+  if (frequency <= 0) {
+    throw new Error("frequency must be positive");
+  }
+
   const sample_count = Math.floor(SAMPLE_RATE / frequency);
   const result = new Float32Array(sample_count);
   for (let i = 0; i < sample_count; i++) {

--- a/sketchlib/waveforms/sample_single_cycle.test.js
+++ b/sketchlib/waveforms/sample_single_cycle.test.js
@@ -33,4 +33,32 @@ describe("sample_single_cycle", () => {
     const expected = 100;
     expect(result.length).toEqual(expected);
   });
+
+  it("with sawtooth wave computes correct values", () => {
+    const sample_count = 12;
+    const freq = SAMPLE_RATE / sample_count;
+
+    const result = sample_single_cycle(sawtooth, freq);
+
+    // This sawtooth wave ramps from 1 to -1 over 12 samples, something like:
+    // lerp(1, -1, i/12)
+    // = (12-i)/12 - i/12
+    // = 12/12 - i/12 - i/12
+    // = 1 - i/6
+    const expected = new Float32Array([
+      1,
+      1 - 1 / 6,
+      1 - 2 / 6,
+      1 - 3 / 6,
+      1 - 4 / 6,
+      1 - 5 / 6,
+      1 - 6 / 6,
+      1 - 7 / 6,
+      1 - 8 / 6,
+      1 - 9 / 6,
+      1 - 10 / 6,
+      1 - 11 / 6,
+    ]);
+    expect(result).toEqual(expected);
+  });
 });

--- a/sketchlib/waveforms/sample_single_cycle.test.js
+++ b/sketchlib/waveforms/sample_single_cycle.test.js
@@ -1,0 +1,36 @@
+import { describe, it, expect } from "vitest";
+import { sample_single_cycle } from "./sample_single_cycle.js";
+import { sawtooth, sine } from "./basic_waves.js";
+import { SAMPLE_RATE } from "./encode_wav.js";
+import { expect_arrays } from "../test_helpers/expect_arrays.js";
+
+describe("sample_single_cycle", () => {
+  it("with zero frequency throws error", () => {
+    expect(() => {
+      return sample_single_cycle(sine, 0);
+    }).toThrowError("frequency must be positive");
+  });
+
+  it("with quarter of sampling rate samples sine correctly", () => {
+    const sample_count = 4;
+    const freq = SAMPLE_RATE / sample_count;
+
+    const result = sample_single_cycle(sine, freq);
+
+    // sampling a sine wave with 4 samples should produce the points at
+    // 0, pi/2, pi, 3pi/2 (but not 2pi! that's the first sample of the next cycle)
+    const expected = new Float32Array([0, 1, 0, -1]);
+    expect_arrays(result, expected, (r, e) => expect(r).toBeCloseTo(e));
+  });
+
+  it("computes correct number of samples for single cycle", () => {
+    // A4 = 440 Hz
+    const freq = 440;
+
+    const result = sample_single_cycle(sawtooth, freq);
+
+    // 44100 / 440 = 100.227, this rounds down to 100
+    const expected = 100;
+    expect(result.length).toEqual(expected);
+  });
+});


### PR DESCRIPTION
This PR adds the following to SoundTest, behind slash commands:

- `/sine` - sine wave
- `/tri` - triangle wave
- `/saw` - sawtooth wave
- `/sqr` - sqr wave