### PR TITLE
Add a convenience method for slash commands

### DIFF
--- a/AnimatedTangle/AnimatedTangle.js
+++ b/AnimatedTangle/AnimatedTangle.js
@@ -145,13 +145,13 @@ const BACKGROUND_STRIPES = style(
   STYLE_BACKGROUND_STRIPES,
 );
 
-const COORDS = new DebugCoordinates(Point.ORIGIN);
+const COORDS = new DebugCoordinates();
 const DEBUG_GRID = new DebugGrid(100, 25);
 
 const SLASH = new KeywordRecognizer();
 
 // /trace logs a trace of the scene for investigating performance issues.
-SLASH.register(["Slash", "KeyT", "KeyR", "KeyA", "KeyC", "KeyE"], () => {
+SLASH.slash("/trace", () => {
   const trace = trace_primitive(TANGLE);
   console.log(trace);
 });

--- a/DifferentialGrowth/DifferentialGrowth.js
+++ b/DifferentialGrowth/DifferentialGrowth.js
@@ -63,7 +63,7 @@ export const sketch = (p) => {
 
     // Typing /ref toggles the reference geometry as well. This is
     // an initial test of KeywordRecognizer for debug tools
-    SLASH.register(["Slash", "KeyR", "KeyE", "KeyF"], () => {
+    SLASH.slash("/ref", () => {
       show_ref_geometry = !show_ref_geometry;
     });
   };

--- a/SoundTest/SoundTest.js
+++ b/SoundTest/SoundTest.js
@@ -243,26 +243,25 @@ const SAMPLE_NOTE = "A2";
 // several instead.
 const CYCLE_COUNT = 100;
 
-// /trace logs a trace of the scene for investigating performance issues.
-SLASH.register(["Slash", "KeyS", "KeyI", "KeyN", "KeyE"], () => {
+SLASH.slash("/sine", () => {
   const samples = sample_n_cycles(sine, SAMPLE_FREQ, CYCLE_COUNT);
   const wav_file = encode_wav_file(samples, `sine-${SAMPLE_NOTE}.wav`);
   download_file(wav_file);
 });
 
-SLASH.register(["Slash", "KeyS", "KeyA", "KeyW"], () => {
+SLASH.slash("/saw", () => {
   const samples = sample_n_cycles(sawtooth, SAMPLE_FREQ, CYCLE_COUNT);
   const wav_file = encode_wav_file(samples, `saw-${SAMPLE_NOTE}.wav`);
   download_file(wav_file);
 });
 
-SLASH.register(["Slash", "KeyT", "KeyR", "KeyI"], () => {
+SLASH.slash("/tri", () => {
   const samples = sample_n_cycles(triangle, SAMPLE_FREQ, CYCLE_COUNT);
   const wav_file = encode_wav_file(samples, `tri-${SAMPLE_NOTE}.wav`);
   download_file(wav_file);
 });
 
-SLASH.register(["Slash", "KeyS", "KeyQ", "KeyR"], () => {
+SLASH.slash("/sqr", () => {
   const samples = sample_n_cycles(square, SAMPLE_FREQ, CYCLE_COUNT);
   const wav_file = encode_wav_file(samples, `square-${SAMPLE_NOTE}.wav`);
   download_file(wav_file);

--- a/SpeechBubble/SpeechBubble.js
+++ b/SpeechBubble/SpeechBubble.js
@@ -77,7 +77,7 @@ const SVG_ELLIPSIS = style(ELLIPSIS_PRINT, STYLE_ELLIPSIS);
 
 const SLASH = new KeywordRecognizer();
 // export SVG version of ellipse
-SLASH.register(["Slash", "KeyS", "KeyV", "KeyG"], () => {
+SLASH.slash("/svg", () => {
   const outline_file = encode_svg_file(
     SVG_OUTLINE,
     "speech-bubble-outline.svg",

--- a/sketchlib/KeywordRecognizer.js
+++ b/sketchlib/KeywordRecognizer.js
@@ -20,6 +20,34 @@ export class KeywordRecognizer {
   }
 
   /**
+   * Shorthand for setting up slash commands
+   * e.g. /debug gets registered as [Slash, KeyD, KeyE, KeyB, KeyU, KeyG]
+   * @param {String} slash_command The slash command. It must begin with /
+   * @param {function(): void} callback The callback to register
+   */
+  slash(slash_command, callback) {
+    if (!slash_command.startsWith("/")) {
+      throw new Error("slash_command must begin with a /");
+    }
+
+    const upper = slash_command.toUpperCase();
+    const keyword = [];
+    for (const c of upper) {
+      if (c === "/") {
+        keyword.push("Slash");
+      } else if (/[A-Z]/.test(c)) {
+        keyword.push(`Key${c}`);
+      } else if (/[0-9]/.test(c)) {
+        keyword.push(`Digit${c}`);
+      } else {
+        throw new Error(`unsupported symbol '${c}' in slash command`);
+      }
+    }
+
+    this.register(keyword, callback);
+  }
+
+  /**
    * Input the next key or other input symbol
    * @param {string} symbol Next input symbol (e.g. a keyboard code)
    */

--- a/sketchlib/KeywordRecognizer.test.js
+++ b/sketchlib/KeywordRecognizer.test.js
@@ -64,4 +64,57 @@ describe("KeywordRecognizer", () => {
       expect(call_count).toBe(1);
     });
   });
+
+  describe("slash", () => {
+    it("without slash throws error", () => {
+      const kw = new KeywordRecognizer();
+
+      expect(() => {
+        return kw.slash("noslash", () => {});
+      }).toThrowError("slash_command must begin with a /");
+    });
+
+    it("with letters produces correct keyword", () => {
+      const kw = new KeywordRecognizer();
+      let call_count = 0;
+
+      kw.slash("/abc", () => {
+        call_count++;
+      });
+      kw.input("Slash");
+      kw.input("KeyA");
+      kw.input("KeyB");
+      kw.input("KeyC");
+
+      expect(call_count).toBe(1);
+    });
+
+    it("with digits produces correct keyword for digit keys", () => {
+      const kw = new KeywordRecognizer();
+      let call_count = 0;
+
+      kw.slash("/42", () => {
+        call_count++;
+      });
+      kw.input("Slash");
+      kw.input("Digit4");
+      kw.input("Digit2");
+
+      expect(call_count).toBe(1);
+    });
+
+    it("with digits does not respond to numpad keys (for now)", () => {
+      const kw = new KeywordRecognizer();
+      let call_count = 0;
+
+      kw.slash("/42", () => {
+        call_count++;
+      });
+      kw.input("Slash");
+      kw.input("Numpad4");
+      kw.input("Numpad2");
+
+      expect(call_count).toBe(0);
+    });
+  });
 });

--- a/sketchlib/Trie.js
+++ b/sketchlib/Trie.js
@@ -6,7 +6,7 @@ export class Trie {
    * Constructor
    * @param {string} symbol The symbol for this node
    * @param {T} [value] A value to store in the node
-   * @param {Trie[]} [children=[]] Children nodes
+   * @param {Trie<T>[]} [children=[]] Children nodes
    */
   constructor(symbol, value, children = []) {
     this.symbol = symbol;


### PR DESCRIPTION
Closes #566 

Instead of writing out `KeyA`, `KeyB`, `KeyC` every time, this allows using `/abc` instead.